### PR TITLE
breastfeeding duration

### DIFF
--- a/fpsim/locations/data_processing/breastfeeding_stats.R
+++ b/fpsim/locations/data_processing/breastfeeding_stats.R
@@ -17,4 +17,4 @@ plot(fitgumbel)
 
 bf_stats <- as.data.frame(fitgumbel$estimate)
 
-save(bf_stats, file = "bf_stats.csv")
+write.csv(bf_stats, file = "bf_stats.csv")

--- a/fpsim/locations/data_processing/breastfeeding_stats.R
+++ b/fpsim/locations/data_processing/breastfeeding_stats.R
@@ -1,0 +1,20 @@
+### Data to process DHS data for breastfeeding duration
+
+dir <- "directory" ## directory with data
+filename <- "filename" ## must be a KR (child recode) file from the DHS for automatic processing
+
+##Breastfeeding duration 
+setwd(dir)
+dat <- read.dta13(filename)
+
+require(ggplot2)
+
+dat_nonmiss <- subset(dat, m5 < 93) #m5 = months of breastfeeding in previous pregnancy
+
+fitgumbel <- fitdist(dat_nonmiss$m5, "gumbel", start=list(a=1, b=1))
+summary(fitgumbel)
+plot(fitgumbel)
+
+bf_stats <- as.data.frame(fitgumbel$estimate)
+
+save(bf_stats, file = "bf_stats.csv")


### PR DESCRIPTION
### Brief description
1. Adds documentation for the breastfeeding duration distribution stats. 

Processing file is generalized to take any DHS KR recode file. Note that PMA does not have any breastfeeding duration information. 

2. Adds breastfeeding stats for Kenya in kenya_bf_stats.csv

### Type(s) of change
- [ ] Bugfix
- [ ] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [ ] Yes
  - [ ] N/A
- I've commented my code
  - [ ] Yes
  - [ ] N/A
- I've incremented the version number
  - [ ] Yes
  - [ ] N/A
- I've updated the changelog
  - [ ] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [ ] Yes
  - [ ] N/A