### PR TITLE
Script for manual calibration with plotting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ All notable changes to the codebase are documented in this file. Changes that ma
    :local:
    :depth: 1
 
+Version 0.22.0 (2023-1-24)
+--------------------------
+- Add calibrate_manual.py to compare sim runs to data with new data structures
+- Add plot_birth_spacing.py under senegal location to fine tune this calibration
+- *GitHub info*: PR `https://github.com/fpsim/fpsim/pull/109>`_
+
 Version 0.21.2 (2022-12-16)
 ---------------------------
 - Updates Kenya, 2nd pass, completed 1st draft

--- a/fpsim/locations/kenya.py
+++ b/fpsim/locations/kenya.py
@@ -61,7 +61,7 @@ def scalar_pars():
         # MCPR
         'mcpr_growth_rate': 0.02,  # The year-on-year change in MCPR after the end of the data
         'mcpr_max': 0.90,  # Do not allow MCPR to increase beyond this
-        'mcpr_norm_year': 2018,  # Year to normalize MCPR trend to 1
+        'mcpr_norm_year': 2020,  # Year to normalize MCPR trend to 1
     }
     return scalar_pars
 

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -368,58 +368,8 @@ sc.toc()
 print('Done.')
 
 
-
 '''
-fig, (ax1, ax2) = pl.subplots(2)
-
-        y_pos1 = pl.arange(len(model_labels_all))
-        all_counts_model = model_method_counts.values()
-
-        ax1.barh(y_pos1, all_counts_model, label = 'FPsim')
-        ax1.set_yticks(y_pos1, labels=model_labels_all)
-        ax1.invert_yaxis()  # labels read top-to-bottom
-        ax1.set_xlabel('Percent method users')
-        ax1.set_title('Method mix in FPsim Kenya including non-use')
-
-        y_pos2 = pl.arange(len(model_labels_methods))
-        model_methods_users = sc.dcp(model_method_counts)
-        model_methods_users['None'] = 0.0
-        model_methods_users[:] /= model_methods_users[:].sum()
-        users_model = model_methods_users.values()[1:]
-        users_percent_model = [i*100 for i in users_model]
-
-        users_percent_data = data_methods_users.values()
-
-        ax2.barh(y_pos2, users_percent_model, label = 'FPsim')
-        ax2.barh(y_pos2, users_percent_data, label = 'PMA')
-        ax2.set_yticks(y_pos2, labels=model_labels_methods)
-        ax2.invert_yaxis()  # labels read top-to-bottom
-        ax2.set_xlabel('Percent method users')
-        ax2.set_title('Method mix in FPsim Kenya')
-
-        pl.show()
-        
-        
-        sky_arr['Data'] = pl.zeros((len(age_bins), len(parity_bins)))
-        count = -1
-        for age_bin in x_age:
-                for pb in parity_bins:
-                        count += 1
-                        parity_bin = min(n_parity - 1, pb)
-                        sky_arr['Data'][age_bin, parity_bin] += sky_props[count]
-        assert count == len(sky_props) - 1  # Ensure they're the right length
-
-        # Extract from model
-        sky_arr['Model'] = pl.zeros((len(age_bins), len(parity_bins)))
-        for i in range(len(ppl)):
-                if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
-                        age_bin = sc.findinds(age_bins <= ppl.age[i])[-1]
-                        parity_bin = sc.findinds(parity_bins <= ppl.parity[i])[-1]
-                        sky_arr['Model'][age_bin, parity_bin] += 1
-
-        # Normalize
-        for key in ['Data', 'Model']:
-                sky_arr[key] /= sky_arr[key].sum() / 100
+Leaving code here in case we want to plot age-parity distribution differently with colormesh
 
 
         fig, axs = pl.subplots(3)
@@ -439,6 +389,5 @@ fig, (ax1, ax2) = pl.subplots(2)
         axs[1].set_ylabel('Parity')
 
         pl.show()
-
 
 '''

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -116,7 +116,7 @@ if do_plot_methods:
         model_method_counts[:] /= model_method_counts[:].sum()
 
         # From data - Kenya PMA 2022 (mix_kenya.csv)
-        data_methods_users = {
+        data_methods_mix = {
                 'Withdrawal': 1.03588605253422,
                 'Other traditional': 4.45800961894192,
                 'Condoms': 8.41657417684055,
@@ -128,19 +128,21 @@ if do_plot_methods:
                 'Other modern': 3.12615612282649
         }
 
-        # Plot bar charts
+        # Plot bar charts of method mix among users
 
-        model_methods_users = sc.dcp(model_method_counts)
-        model_methods_users['None'] = 0.0
-        model_methods_users[:] /= model_methods_users[:].sum()
-        users_model = model_methods_users.values()[1:]
-        users_percent_model = [i * 100 for i in users_model]
+        model_methods_mix = sc.dcp(model_method_counts)
+        model_none_sum = model_methods_mix['None']
+        model_methods_mix['None'] = 0.0
+        model_users_sum = model_methods_mix[:].sum()
+        model_methods_mix[:] /= model_users_sum
+        mix_model = model_methods_mix.values()[1:]
+        mix_percent_model = [i * 100 for i in mix_model]
 
-        users_percent_data = list(data_methods_users.values())
+        mix_percent_data = list(data_methods_mix.values())
 
-        data = users_percent_data
-        model = users_percent_model
-        df = pd.DataFrame({'PMA': data, 'FPsim': model}, index=model_labels_methods)
+        data_mix = mix_percent_data
+        model_mix = mix_percent_model
+        df = pd.DataFrame({'PMA': data_mix, 'FPsim': model_mix}, index=model_labels_methods)
 
         ax = df.plot.barh()
         ax.set_xlabel('Percent users')

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -1,6 +1,7 @@
 '''
-The very start of a script for running plotting to compare the model to data
+A script for running plotting to compare the model to data
 '''
+
 import numpy as np
 import pandas as pd
 import sciris as sc
@@ -15,6 +16,9 @@ do_plot_sim = True
 do_plot_asfr = True
 do_plot_methods = True
 do_plot_skyscrapers = True
+do_plot_cpr = True
+do_plot_tfr = True
+do_plot_pop_growth = True
 
 
 # Set up global variables
@@ -238,7 +242,40 @@ if do_plot_skyscrapers:
 
                 pl.show()
 
+if do_plot_cpr:
 
+        # Import data
+        data_cpr = pd.read_csv('kenya_cpr.csv') # From UN Data Portal
+        data_cpr = data_cpr[data_cpr['year'] <= 2020] # Restrict years to plot
+
+        pl.plot(data_cpr['year'], data_cpr['cpr'], label='UN Data Portal')
+        pl.plot(res['t'], res['cpr']*100, label='FPsim')
+        pl.xlabel('Year')
+        pl.ylabel('Percent')
+        pl.title('Contraceptive Prevalence Rate in Data vs Model - Kenya')
+        pl.legend()
+
+        pl.savefig('figs/cpr_over_sim.png')
+        pl.show()
+
+if do_plot_tfr:
+
+        # Import data
+        data_tfr = pd.read_csv('kenya_tfr.csv')
+
+        pl.plot(data_tfr['year'], data_tfr['tfr'], label='World Bank')
+        pl.plot(res['tfr_years'], res['tfr_rates'], label='FPsim')
+        pl.xlabel('Year')
+        pl.ylabel('Rate')
+        pl.title('Total Fertility Rate in Data vs Model - Kenya')
+        pl.legend()
+
+        pl.savefig('figs/tfr_over_sim.png')
+        pl.show()
+
+
+
+#if do_plot_pop_growth:
 
 
 

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -1,26 +1,20 @@
 '''
 The very start of a script for running plotting to compare the model to data
 '''
-
-
+import numpy as np
+import pandas as pd
 import sciris as sc
 import fpsim as fp
 import pylab as pl
 
-# Set options
-do_plot = True
-pars = fp.pars(location='kenya')
-pars['n_agents'] = 50000 # Small population size
-pars['end_year'] = 2020 # 1961 - 2020 is the normal date range
-pars['exposure_correction'] = 1.0 # Overall scale factor on probability of becoming pregnant
+# Set options for plotting
+do_plot_sim = True
+do_plot_asfr = True
+do_plot_methods = True
+do_plot_skyscrapers = True
 
-sc.tic()
-sim = fp.Sim(pars=pars)
-sim.run()
 
-if do_plot:
-    sim.plot()
-
+# Set up global variables
 age_bin_map = {
         '10-14': [10, 15],
         '15-19': [15, 20],
@@ -32,32 +26,280 @@ age_bin_map = {
         '45-49': [45, 50]
 }
 
+min_age = 15
+max_age = 50
+bin_size = 5
+
+skyscrapers = pd.read_csv('kenya_skyscrapers.csv')
+use = pd.read_csv('use_kenya.csv')
+
+dataset = 'PMA 2022'  # Data to compare to for skyscrapers
+
+
+sc.tic()
+
+
+# Set up sim for Kenya
+pars = fp.pars(location='kenya')
+pars['n_agents'] = 100_000 # Small population size
+pars['end_year'] = 2020 # 1961 - 2020 is the normal date range
+
+# Free parameters for calibration
+pars['fecundity_var_low'] = 0.95
+pars['fecundity_var_high'] = 1.05
+
+sim = fp.Sim(pars=pars)
+sim.run()
+
+if do_plot_sim:
+    sim.plot()
+
+# Save results
 res = sim.results
 
-for key in age_bin_map.keys():
+
+if do_plot_asfr:
+        for key in age_bin_map.keys():
             print(f'ASFR (annual) for age bin {key} in the last year of the sim: {res["asfr"][key][-1]}')
 
-x = [1, 2, 3, 4, 5, 6, 7, 8]
-asfr_data = [3.03, 64.94, 172.12, 174.12, 136.10, 80.51, 34.88, 13.12]  # From UN Data Kenya 2020
-x_labels = []
-asfr_model = []
+        x = [1, 2, 3, 4, 5, 6, 7, 8]
+        asfr_data = [3.03, 64.94, 172.12, 174.12, 136.10, 80.51, 34.88, 13.12]  # From UN Data Kenya 2020
+        x_labels = []
+        asfr_model = []
 
-for key in age_bin_map.keys():
-        x_labels.append(key)
-        asfr_model.append(res['asfr'][key][-1])
+        for key in age_bin_map.keys():
+                x_labels.append(key)
+                asfr_model.append(res['asfr'][key][-1])
 
-fig, ax = pl.subplots()
-kw = dict(lw=3, alpha=0.7, markersize=10)
-ax.plot(x, asfr_data, marker='^', color='black', label="UN data", **kw)
-ax.plot(x, asfr_model, marker='*', color='cornflowerblue', label="FPsim", **kw)
-pl.xticks(x, x_labels)
-pl.ylim(bottom=-10)
-ax.set_title('Age specific fertility rate per 1000 woman years')
-ax.set_xlabel('Age')
-ax.set_ylabel('ASFR in 2019')
-ax.legend(frameon=False)
-sc.boxoff()
-pl.show()
+        fig, ax = pl.subplots()
+        kw = dict(lw=3, alpha=0.7, markersize=10)
+        ax.plot(x, asfr_data, marker='^', color='black', label="UN data", **kw)
+        ax.plot(x, asfr_model, marker='*', color='cornflowerblue', label="FPsim", **kw)
+        pl.xticks(x, x_labels)
+        pl.ylim(bottom=-10)
+        ax.set_title('Age specific fertility rate per 1000 woman years')
+        ax.set_xlabel('Age')
+        ax.set_ylabel('ASFR in 2019')
+        ax.legend(frameon=False)
+        sc.boxoff()
+        pl.savefig('figs/asfr.png')
+        pl.show()
+
+if do_plot_methods:
+
+        methods_map_model = {  # Index, modern, efficacy
+        'None': [0, False, 0.000],
+        'Withdrawal': [1, False, 0.866],
+        'Other traditional': [2, False, 0.861],
+        # 1/2 periodic abstinence, 1/2 other traditional approx.  Using rate from periodic abstinence
+        'Condoms': [3, True, 0.946],
+        'Pill': [4, True, 0.945],
+        'Injectables': [5, True, 0.983],
+        'Implants': [6, True, 0.994],
+        'IUDs': [7, True, 0.986],
+        'BTL': [8, True, 0.995],
+        'Other modern': [9, True, 0.880],
+        }
+
+        model_labels_all = list(methods_map_model.keys())
+        model_labels_methods = sc.dcp(model_labels_all)
+        model_labels_methods = model_labels_methods[1:]
+
+        model_method_counts = sc.odict().make(keys=model_labels_all, vals=0.0)
+
+        # From model
+        ppl = sim.people
+        for i in range(len(ppl)):
+                if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
+                        model_method_counts[ppl.method[i]] += 1
+
+        model_method_counts[:] /= model_method_counts[:].sum()
+
+        # From data - Kenya PMA 2022 (mix_kenya.csv)
+        data_methods_users = {
+                'Withdrawal': 1.03588605253422,
+                'Other traditional': 4.45800961894192,
+                'Condoms': 8.41657417684055,
+                'Pill': 7.95412504624491,
+                'Injectables': 34.0732519422863,
+                'Implants': 33.9622641509434,
+                'IUDs': 3.08916019237884,
+                'BTL': 3.88457269700333,
+                'Other modern': 3.12615612282649
+        }
+
+        # Plot bar charts
+
+        model_methods_users = sc.dcp(model_method_counts)
+        model_methods_users['None'] = 0.0
+        model_methods_users[:] /= model_methods_users[:].sum()
+        users_model = model_methods_users.values()[1:]
+        users_percent_model = [i * 100 for i in users_model]
+
+        users_percent_data = list(data_methods_users.values())
+
+        data = users_percent_data
+        model = users_percent_model
+        df = pd.DataFrame({'PMA': data, 'FPsim': model}, index=model_labels_methods)
+
+        ax = df.plot.barh()
+        ax.set_xlabel('Percent users')
+        ax.set_title('Contraceptive method mix model vs data')
+
+        pl.savefig("figs/method_mix.png", bbox_inches='tight', dpi=100)
+
+        #pl.show()
+
+
+if do_plot_skyscrapers:
+
+        age_keys = list(age_bin_map.keys())[1:]
+        print(f'/age keys: {age_keys}')
+        age_bins = pl.arange(min_age, max_age, bin_size)
+        parity_bins = pl.arange(0, 7)
+        n_age = len(age_bins)
+        n_parity = len(parity_bins)
+        x_age = pl.arange(n_age)
+        x_parity = pl.arange(n_parity)  # Should be the same
+
+        # Load data
+        data_parity_bins = pl.arange(0,7)
+        sky_raw_data = skyscrapers
+        sky_raw_data = sky_raw_data[sky_raw_data['dataset'] == dataset]
+        print(f'Sky raw data: {sky_raw_data}')
+
+        sky_parity = sky_raw_data['parity'].to_numpy()
+        sky_props = sky_raw_data['percentage'].to_numpy()
+
+
+        sky_arr = sc.odict()
+
+        sky_arr['Data'] = pl.zeros((len(age_keys), len(parity_bins)))
+
+        proportion = 0
+        age_name = ''
+        for age, row in sky_raw_data.iterrows():
+                if row.age in age_keys:
+                        age_ind = age_keys.index(row.age)
+                        sky_arr['Data'][age_ind, row.parity] = row.percentage
+
+
+        # Extract from model
+        sky_arr['Model'] = pl.zeros((len(age_bins), len(parity_bins)))
+        ppl = sim.people
+        for i in range(len(ppl)):
+                if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
+                        age_bin = sc.findinds(age_bins <= ppl.age[i])[-1]
+                        parity_bin = sc.findinds(parity_bins <= ppl.parity[i])[-1]
+                        sky_arr['Model'][age_bin, parity_bin] += 1
+
+
+        # Normalize
+        for key in ['Data', 'Model']:
+                sky_arr[key] /= sky_arr[key].sum() / 100
+
+        print(f'sky_arr_model: {sky_arr["Model"]}')
+        print(f'sky_arr_data: {sky_arr["Data"]}')
+
+        sky_arr['Diff: data - model'] = sky_arr['Data']-sky_arr['Model']
+
+        # Plot skyscrapers
+        for key in ['Data', 'Model', 'Diff: data - model']:
+                fig = pl.figure(figsize=(20, 14))
+
+                sc.bar3d(fig=fig, data=sky_arr[key], cmap='jet')
+                pl.xlabel('Age', fontweight='bold')
+                pl.ylabel('Parity', fontweight='bold')
+                pl.title(f'Age-parity plot for the {key.lower()}\n\n', fontweight='bold')
+                pl.gca().set_xticks(pl.arange(n_age))
+                pl.gca().set_yticks(pl.arange(n_parity))
+                pl.gca().set_xticklabels(age_bins)
+                pl.gca().set_yticklabels(parity_bins)
+                pl.gca().view_init(30, 45)
+                pl.draw()
+
+                pl.savefig('figs/skyscrapers_' + str(key.lower()) + '.png')
+
+                pl.show()
+
+
+
+
 
 sc.toc()
 print('Done.')
+
+
+'''
+fig, (ax1, ax2) = pl.subplots(2)
+
+        y_pos1 = pl.arange(len(model_labels_all))
+        all_counts_model = model_method_counts.values()
+
+        ax1.barh(y_pos1, all_counts_model, label = 'FPsim')
+        ax1.set_yticks(y_pos1, labels=model_labels_all)
+        ax1.invert_yaxis()  # labels read top-to-bottom
+        ax1.set_xlabel('Percent method users')
+        ax1.set_title('Method mix in FPsim Kenya including non-use')
+
+        y_pos2 = pl.arange(len(model_labels_methods))
+        model_methods_users = sc.dcp(model_method_counts)
+        model_methods_users['None'] = 0.0
+        model_methods_users[:] /= model_methods_users[:].sum()
+        users_model = model_methods_users.values()[1:]
+        users_percent_model = [i*100 for i in users_model]
+
+        users_percent_data = data_methods_users.values()
+
+        ax2.barh(y_pos2, users_percent_model, label = 'FPsim')
+        ax2.barh(y_pos2, users_percent_data, label = 'PMA')
+        ax2.set_yticks(y_pos2, labels=model_labels_methods)
+        ax2.invert_yaxis()  # labels read top-to-bottom
+        ax2.set_xlabel('Percent method users')
+        ax2.set_title('Method mix in FPsim Kenya')
+
+        pl.show()
+        
+        
+        sky_arr['Data'] = pl.zeros((len(age_bins), len(parity_bins)))
+        count = -1
+        for age_bin in x_age:
+                for pb in parity_bins:
+                        count += 1
+                        parity_bin = min(n_parity - 1, pb)
+                        sky_arr['Data'][age_bin, parity_bin] += sky_props[count]
+        assert count == len(sky_props) - 1  # Ensure they're the right length
+
+        # Extract from model
+        sky_arr['Model'] = pl.zeros((len(age_bins), len(parity_bins)))
+        for i in range(len(ppl)):
+                if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
+                        age_bin = sc.findinds(age_bins <= ppl.age[i])[-1]
+                        parity_bin = sc.findinds(parity_bins <= ppl.parity[i])[-1]
+                        sky_arr['Model'][age_bin, parity_bin] += 1
+
+        # Normalize
+        for key in ['Data', 'Model']:
+                sky_arr[key] /= sky_arr[key].sum() / 100
+
+
+        fig, axs = pl.subplots(3)
+
+        fig.suptitle('Age Parity Distribution')
+
+        axs[0].pcolormesh(age_bins, parity_bins, sky_arr.Data.transpose(), shading='nearest', cmap='turbo')
+        axs[0].set_aspect(1. / ax.get_data_ratio())  # Make square
+        axs[0].set_title('Age-parity plot: Kenya PMA 2022')
+        axs[0].set_xlabel('Age')
+        ax[0].set_ylabel('Parity')
+
+        axs[1].pcolormesh(age_bins, parity_bins, sky_arr.Model.transpose(), shading='nearest', cmap='turbo')
+        axs[1].set_aspect(1. / ax.get_data_ratio())  # Make square
+        axs[1].set_title('Age-parity plot: Kenya PMA 2022')
+        axs[1].set_xlabel('Age')
+        axs[1].set_ylabel('Parity')
+
+        pl.show()
+
+
+'''

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -63,7 +63,7 @@ if do_plot_asfr:
             print(f'ASFR (annual) for age bin {key} in the last year of the sim: {res["asfr"][key][-1]}')
 
         x = [1, 2, 3, 4, 5, 6, 7, 8]
-        asfr_data = [3.03, 64.94, 172.12, 174.12, 136.10, 80.51, 34.88, 13.12]  # From UN Data Kenya 2020
+        asfr_data = [3.03, 64.94, 172.12, 174.12, 136.10, 80.51, 34.88, 13.12]  # From UN Data Kenya 2020 (kenya_asfr.csv)
         x_labels = []
         asfr_model = []
 
@@ -128,27 +128,46 @@ if do_plot_methods:
                 'Other modern': 3.12615612282649
         }
 
-        # Plot bar charts of method mix among users
+        # From data - Kenya PMA 2022 (use_kenya.csv)
+        data_methods_use = {
+                'No use': 51.1078954508456,
+                'Any method': 48.8921045491544
+        }
 
+        # Plot bar charts of method mix and use among users
+
+        # Calculate users vs non-users in model
         model_methods_mix = sc.dcp(model_method_counts)
-        model_none_sum = model_methods_mix['None']
+        model_use = [model_methods_mix['None'], model_methods_mix[1:].sum()]
+        model_use_percent = [i * 100 for i in model_use]
+
+        # Calculate mix within users in model
         model_methods_mix['None'] = 0.0
         model_users_sum = model_methods_mix[:].sum()
         model_methods_mix[:] /= model_users_sum
         mix_model = model_methods_mix.values()[1:]
         mix_percent_model = [i * 100 for i in mix_model]
 
+        # Set method use and mix from data
         mix_percent_data = list(data_methods_mix.values())
+        data_use_percent = list(data_methods_use.values())
 
-        data_mix = mix_percent_data
-        model_mix = mix_percent_model
-        df = pd.DataFrame({'PMA': data_mix, 'FPsim': model_mix}, index=model_labels_methods)
+        # Set up plotting
+        use_labels = list(data_methods_use.keys())
+        df_mix = pd.DataFrame({'PMA': mix_percent_data, 'FPsim': mix_percent_model}, index=model_labels_methods)
+        df_use = pd.DataFrame({'PMA': data_use_percent, 'FPsim': model_use_percent}, index=use_labels)
 
-        ax = df.plot.barh()
+        ax = df_mix.plot.barh()
         ax.set_xlabel('Percent users')
         ax.set_title('Contraceptive method mix model vs data')
 
         pl.savefig("figs/method_mix.png", bbox_inches='tight', dpi=100)
+
+        ax = df_use.plot.barh()
+        ax.set_xlabel('Percent')
+        ax.set_title('Contraceptive method use model vs data')
+
+        pl.savefig("figs/method_use.png", bbox_inches='tight', dpi=100)
 
         #pl.show()
 

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -7,6 +7,9 @@ import sciris as sc
 import fpsim as fp
 import pylab as pl
 
+
+sc.tic()
+
 # Set options for plotting
 do_plot_sim = True
 do_plot_asfr = True
@@ -34,9 +37,6 @@ skyscrapers = pd.read_csv('kenya_skyscrapers.csv')
 use = pd.read_csv('use_kenya.csv')
 
 dataset = 'PMA 2022'  # Data to compare to for skyscrapers
-
-
-sc.tic()
 
 
 # Set up sim for Kenya
@@ -175,7 +175,6 @@ if do_plot_methods:
 if do_plot_skyscrapers:
 
         age_keys = list(age_bin_map.keys())[1:]
-        print(f'/age keys: {age_keys}')
         age_bins = pl.arange(min_age, max_age, bin_size)
         parity_bins = pl.arange(0, 7)
         n_age = len(age_bins)
@@ -187,7 +186,6 @@ if do_plot_skyscrapers:
         data_parity_bins = pl.arange(0,7)
         sky_raw_data = skyscrapers
         sky_raw_data = sky_raw_data[sky_raw_data['dataset'] == dataset]
-        print(f'Sky raw data: {sky_raw_data}')
 
         sky_parity = sky_raw_data['parity'].to_numpy()
         sky_props = sky_raw_data['percentage'].to_numpy()
@@ -218,9 +216,6 @@ if do_plot_skyscrapers:
         # Normalize
         for key in ['Data', 'Model']:
                 sky_arr[key] /= sky_arr[key].sum() / 100
-
-        print(f'sky_arr_model: {sky_arr["Model"]}')
-        print(f'sky_arr_data: {sky_arr["Data"]}')
 
         sky_arr['Diff: data - model'] = sky_arr['Data']-sky_arr['Model']
 

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -40,12 +40,12 @@ bin_size = 5
 skyscrapers = pd.read_csv('kenya_skyscrapers.csv')
 use = pd.read_csv('use_kenya.csv')
 
-dataset = 'PMA 2022'  # Data to compare to for skyscrapers
+dataset = 'DHS 2014'  # Data to compare to for skyscrapers
 
 
 # Set up sim for Kenya
 pars = fp.pars(location='kenya')
-pars['n_agents'] = 100_000 # Small population size
+pars['n_agents'] = 10_000 # Small population size
 pars['end_year'] = 2020 # 1961 - 2020 is the normal date range
 
 # Free parameters for calibration
@@ -55,11 +55,23 @@ pars['fecundity_var_high'] = 1.05
 sim = fp.Sim(pars=pars)
 sim.run()
 
+
 if do_plot_sim:
     sim.plot()
 
 # Save results
 res = sim.results
+
+
+def pop_growth_rate(years, population):
+        growth_rate = np.zeros(len(years) - 1)
+
+        for i in range(len(years)):
+                if population[i] == population[-1]:
+                        break
+                growth_rate[i] = ((population[i + 1] - population[i]) / population[i]) * 100
+
+        return growth_rate
 
 
 if do_plot_asfr:
@@ -273,9 +285,26 @@ if do_plot_tfr:
         pl.savefig('figs/tfr_over_sim.png')
         pl.show()
 
+if do_plot_pop_growth:
 
+        data_popsize = pd.read_csv('kenya_popsize.csv')
+        data_popsize = data_popsize[data_popsize['year'] <= 2020]  # Restrict years to plot
 
-#if do_plot_pop_growth:
+        data_pop_years = data_popsize['year'].to_numpy()
+        data_population = data_popsize['population'].to_numpy()
+
+        model_growth_rate = pop_growth_rate(res['tfr_years'], res['pop_size'])
+        data_growth_rate = pop_growth_rate(data_pop_years, data_population)
+
+        pl.plot(data_pop_years[1:], data_growth_rate, label='World Bank', color='black')
+        pl.plot(res['tfr_years'][1:], model_growth_rate, label='FPsim', color='cornflowerblue')
+        pl.xlabel('Year')
+        pl.ylabel('Rate')
+        pl.title('Population Growth Rate Data vs Model - Kenya')
+        pl.legend()
+
+        pl.savefig('figs/popgrowth_over_sim.png')
+        pl.show()
 
 
 

--- a/fpsim/locations/kenya/calibrate_manual.py
+++ b/fpsim/locations/kenya/calibrate_manual.py
@@ -161,13 +161,13 @@ if do_plot_methods:
         df_mix = pd.DataFrame({'PMA': mix_percent_data, 'FPsim': mix_percent_model}, index=model_labels_methods)
         df_use = pd.DataFrame({'PMA': data_use_percent, 'FPsim': model_use_percent}, index=use_labels)
 
-        ax = df_mix.plot.barh()
+        ax = df_mix.plot.barh(color={'PMA':'black', 'FPsim':'cornflowerblue'})
         ax.set_xlabel('Percent users')
         ax.set_title('Contraceptive method mix model vs data')
 
         pl.savefig("figs/method_mix.png", bbox_inches='tight', dpi=100)
 
-        ax = df_use.plot.barh()
+        ax = df_use.plot.barh(color={'PMA':'black', 'FPsim':'cornflowerblue'})
         ax.set_xlabel('Percent')
         ax.set_title('Contraceptive method use model vs data')
 
@@ -248,8 +248,8 @@ if do_plot_cpr:
         data_cpr = pd.read_csv('kenya_cpr.csv') # From UN Data Portal
         data_cpr = data_cpr[data_cpr['year'] <= 2020] # Restrict years to plot
 
-        pl.plot(data_cpr['year'], data_cpr['cpr'], label='UN Data Portal')
-        pl.plot(res['t'], res['cpr']*100, label='FPsim')
+        pl.plot(data_cpr['year'], data_cpr['cpr'], label='UN Data Portal', color='black')
+        pl.plot(res['t'], res['cpr']*100, label='FPsim', color='cornflowerblue')
         pl.xlabel('Year')
         pl.ylabel('Percent')
         pl.title('Contraceptive Prevalence Rate in Data vs Model - Kenya')
@@ -263,8 +263,8 @@ if do_plot_tfr:
         # Import data
         data_tfr = pd.read_csv('kenya_tfr.csv')
 
-        pl.plot(data_tfr['year'], data_tfr['tfr'], label='World Bank')
-        pl.plot(res['tfr_years'], res['tfr_rates'], label='FPsim')
+        pl.plot(data_tfr['year'], data_tfr['tfr'], label='World Bank', color='black')
+        pl.plot(res['tfr_years'], res['tfr_rates'], label='FPsim', color='cornflowerblue')
         pl.xlabel('Year')
         pl.ylabel('Rate')
         pl.title('Total Fertility Rate in Data vs Model - Kenya')

--- a/fpsim/locations/kenya/explore_plotting.py
+++ b/fpsim/locations/kenya/explore_plotting.py
@@ -1,0 +1,80 @@
+'''
+A script to test plotting function for FPsim
+Goal is to use plot functions to compare model vs data for specific outputs:
+    - CPR
+    - Maternal mortality ratio
+    - Infant mortality rate
+    - Population growth?
+    - TFR?
+'''
+
+
+import numpy as np
+import pandas as pd
+import sciris as sc
+import fpsim as fp
+import pylab as pl
+
+sc.tic()
+
+# Set up sim for Kenya
+pars = fp.pars(location='kenya')
+pars['n_agents'] = 100_000 # Small population size
+pars['end_year'] = 2020 # 1961 - 2020 is the normal date range
+
+# Free parameters for calibration
+pars['fecundity_var_low'] = 0.9
+pars['fecundity_var_high'] = 1.1
+
+sim = fp.Sim(pars=pars)
+sim.run()
+
+# sim.plot(to_plot = {'cpr':  'CPR (contraceptive prevalence rate)'}, do_save=True, filename='sim_cpr.png', new_fig=True)
+
+# Save results
+res = sim.results
+
+# Import data
+data_cpr = pd.read_csv('kenya_cpr.csv') # From UN Data Portal
+data_cpr = data_cpr[data_cpr['year'] <= 2020] # Restrict years to plot
+
+pl.plot(data_cpr['year'], data_cpr['cpr'], label='UN Data Portal Kenya')
+pl.plot(res['t'], res['cpr']*100, label='FPsim')
+pl.xlabel('Year')
+pl.ylabel('Percent')
+pl.title('Contraceptive Prevalence Rate in Data vs Model')
+pl.legend()
+pl.show()
+
+# Plot birth spacing
+
+
+
+# Maternal mortality ratio end of model
+
+maternal_deaths = np.sum(self.model_results['maternal_deaths'][-mpy * 3:])
+        births_last_3_years = np.sum(self.model_results['births'][-mpy * 3:])
+        self.model['maternal_mortality_ratio'] = (maternal_deaths / births_last_3_years) * 100000
+
+
+def model_infant_mortality_rate(self):
+        infant_deaths = np.sum(self.model_results['infant_deaths'][-mpy:])
+        births_last_year = np.sum(self.model_results['births'][-mpy:])
+        self.model['infant_mortality_rate'] = (infant_deaths / births_last_year) * 1000
+
+        return
+
+
+def model_crude_death_rate(self):
+        total_deaths = np.sum(self.model_results['deaths'][-mpy:]) + \
+                       np.sum(self.model_results['infant_deaths'][-mpy:]) + \
+                       np.sum(self.model_results['maternal_deaths'][-mpy:])
+        self.model['crude_death_rate'] = (total_deaths / self.model_results['pop_size'][-1]) * 1000
+        return
+
+
+def model_crude_birth_rate(self):
+        births_last_year = np.sum(self.model_results['births'][-mpy:])
+        self.model['crude_birth_rate'] = (births_last_year / self.model_results['pop_size'][-1]) * 1000
+        return
+

--- a/fpsim/locations/senegal/plot_birth_spacing.py
+++ b/fpsim/locations/senegal/plot_birth_spacing.py
@@ -1,0 +1,123 @@
+'''
+A script to specifically look at data comparison to birth spacing
+Birth spacing data comes from senegal.py in the format .obj
+No other calibrated location at this point has a birth spacing file
+'''
+
+import numpy as np
+import pandas as pd
+import sciris as sc
+import fpsim as fp
+import pylab as pl
+import numpy as np
+
+do_plot_sim = 1
+
+spacing_file = 'BirthSpacing.obj'
+
+min_age = 15
+max_age = 50
+
+# Load birth spacing data
+data = sc.load(spacing_file)
+
+# Set up sim for Senegal
+pars = fp.pars(location='senegal')
+pars['n_agents'] = 100_000 # Population size
+pars['end_year'] = 2020 # 1961 - 2020 is the normal date range
+
+# Free parameters for calibration
+pars['fecundity_var_low'] = 0.7
+pars['fecundity_var_high'] = 1.1
+
+sim = fp.Sim(pars=pars)
+sim.run()
+
+if do_plot_sim:
+    sim.plot()
+
+
+spacing_bins = sc.odict({'0-12': 0, '12-24': 1, '24-48': 2, '>48': 4})  # Spacing bins in years
+data_dict = {}
+model_dict = {} # For comparison from model to data
+
+# Extract birth spacing data from  data
+spacing, first = data['spacing'], data['first'] # Extract from data
+data_spacing_counts = sc.odict().make(keys=spacing_bins.keys(), vals=0.0)
+
+# Spacing bins from data
+spacing_bins_array = sc.cat(spacing_bins[:], np.inf)
+for i in range(len(spacing_bins_array)-1):
+    lower = spacing_bins_array[i]
+    upper = spacing_bins_array[i+1]
+    matches = np.intersect1d(sc.findinds(spacing >= lower), sc.findinds(spacing < upper))
+    data_spacing_counts[i] += len(matches)
+
+data_spacing_counts[:] /= data_spacing_counts[:].sum()
+data_spacing_counts[:] *= 100
+data_spacing_stats = np.array([pl.percentile(spacing, 25),
+                                pl.percentile(spacing, 50),
+                                pl.percentile(spacing, 75)])
+data_age_first_stats = np.array([pl.percentile(first, 25),
+                                    pl.percentile(first, 50),
+                                    pl.percentile(first, 75)])
+
+# Save to dictionary
+data_dict['spacing_bins'] = np.array(data_spacing_counts.values())
+data_dict['spacing_stats'] = data_spacing_stats
+data_dict['age_first_stats'] = data_age_first_stats
+
+# From model
+model_age_first = []
+model_spacing = []
+model_spacing_counts = sc.odict().make(keys=spacing_bins.keys(), vals=0.0)
+ppl = sim.people
+for i in  range(len(ppl)):
+    if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
+        if len(ppl.dobs[i]):
+            model_age_first.append(ppl.dobs[i][0])
+        if len(ppl.dobs[i]) > 1:
+            for d in range(len(ppl.dobs[i]) - 1):
+                space = ppl.dobs[i][d + 1] - ppl.dobs[i][d]
+                ind = sc.findinds(space > spacing_bins[:])[-1]
+                model_spacing_counts[ind] += 1
+                model_spacing.append(space)
+
+model_spacing_counts[:] /= model_spacing_counts[:].sum()
+model_spacing_counts[:] *= 100
+try:
+    model_spacing_stats = np.array([np.percentile(model_spacing, 25),
+                                    np.percentile(model_spacing, 50),
+                                    np.percentile(model_spacing, 75)])
+    model_age_first_stats = np.array([np.percentile(model_age_first, 25),
+                                    np.percentile(model_age_first, 50),
+                                    np.percentile(model_age_first, 75)])
+except Exception as E: # pragma: nocover
+        print(f'Could not calculate birth spacing, returning zeros: {E}')
+        model_spacing_counts = {k:0 for k in spacing_bins.keys()}
+        model_spacing_stats = np.zeros(data_spacing_stats.shape)
+        model_age_first_stats = np.zeros(data_age_first_stats.shape)
+
+# Save arrays to dictionary
+model_dict['spacing_bins'] = np.array(model_spacing_counts.values())
+model_dict['spacing_stats'] = model_spacing_stats
+model_dict['age_first_stats'] = model_age_first_stats
+
+#diff_dict = sc.odict().make(keys=model_dict.keys(), vals=(model_dict.values() - data_dict.values()))
+
+diff = model_dict['spacing_bins'] - data_dict['spacing_bins']
+
+res_bins = np.array([[model_dict['spacing_bins']], [data_dict['spacing_bins']], [diff]])
+
+bins_frame = pd.DataFrame({'Model': model_dict['spacing_bins'], 'Data': data_dict['spacing_bins'], 'Diff': diff}, index=spacing_bins.keys())
+
+print(bins_frame)
+
+
+# Plot spacing bins
+ax = bins_frame.plot.barh(color={'Data':'black', 'Model':'cornflowerblue', 'Diff':'red'})
+ax.set_xlabel('Percent of live birth spaces')
+ax.set_ylabel('Birth space in months')
+ax.set_title('Birth space bins calibration - Senegal')
+
+pl.savefig("birth_space_bins.png", bbox_inches='tight', dpi=100)

--- a/fpsim/version.py
+++ b/fpsim/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.21.2'
-__versiondate__ = '2022-12-16'
+__version__ = '0.22.0'
+__versiondate__ = '2023-1-24'
 __license__ = f'FPsim {__version__} ({__versiondate__}) — © 2019-2022 by IDM'


### PR DESCRIPTION
### Brief description
This creates a new script called "calibrate_manual.py" that runs a simulation and compares the model results from the run to data for calibration.  The current plots generated are:

End states:
1.  ASFR 
2. Method mix 
3. Method use 
4. Age-parity distribution 
5. Birth spacing

Over time:
6. Contraceptive prevalence rate
7. TFR
8. Population growth rate

Also adds a script "plot_birth_spacing,py" under senegal location to help with fine tuning birth space calibration

Closes #60 for now, can add more functionality to this script as needed

Outputs are shown here:

![asfr](https://user-images.githubusercontent.com/65202227/214409281-06c1e862-0b20-4dd7-9f4b-565b8d9546d5.png)
![birth_space_bins](https://user-images.githubusercontent.com/65202227/214409285-c76d5f0f-b064-4905-ad12-1e797148768a.png)
![cpr_over_sim](https://user-images.githubusercontent.com/65202227/214409286-a2d9b66d-7d51-4da7-900c-c89d04c1ba21.png)
![method_mix](https://user-images.githubusercontent.com/65202227/214409290-aeab4629-d118-4fb1-842d-2124047650d6.png)
![method_use](https://user-images.githubusercontent.com/65202227/214409292-3e9ea841-f067-4fb5-8398-6876dc4c9ddd.png)
![popgrowth_over_sim](https://user-images.githubusercontent.com/65202227/214409295-6e35beda-8f87-4ed3-857f-060b261854f3.png)
![skyscrapers_data](https://user-images.githubusercontent.com/65202227/214409298-bcb34736-64a5-4579-937e-1647ecb85fe6.png)
![skyscrapers_diff: data - model](https://user-images.githubusercontent.com/65202227/214409302-6634c86d-616c-4e10-bcc7-83cee388a558.png)
![skyscrapers_model](https://user-images.githubusercontent.com/65202227/214409304-55cb76db-0c67-4fa3-8000-a1dab1a47eaa.png)
![tfr_over_sim](https://user-images.githubusercontent.com/65202227/214409306-3a520f9e-2557-46c7-8f0a-73a0caacbf86.png)


### Type(s) of change
- [ ] Bugfix
- [ ] Refactor
- [x] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [x] Yes
  - [ ] N/A
- I've commented my code
  - [x] Yes
  - [ ] N/A
- I've incremented the version number
  - [x] Yes
  - [ ] N/A
- I've updated the changelog
  - [x] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [x] Yes
  - [ ] N/A