### PR TITLE
Restrict contraceptive uptake to sexually active agents 

### DIFF
--- a/analyses/explore_method_use.py
+++ b/analyses/explore_method_use.py
@@ -1,0 +1,103 @@
+'''
+Explore dynamics around agents on methods with limited or no historical sexual activity
+'''
+
+import sciris as sc
+import fpsim as fp
+import pandas as pd
+import seaborn as sns
+import pylab as pl
+
+# Set globals
+max_age = 50
+min_age = 15
+
+# Set options
+do_plot_sim = False
+
+# Set up sim parameters
+pars = fp.pars(location='kenya')
+pars['n_agents'] = 100_000 # Small population size
+
+sc.tic()
+sim = fp.Sim(pars=pars)
+sim.run()
+
+if do_plot_sim:
+    sim.plot()
+
+# Save results
+res = sim.results
+
+# Save people from sim
+ppl = sim.people
+
+# Extract synthetic cohort of live women age 15-49 and find how many users haven't debuted
+
+all_women = 0
+method_users = 0
+use_before_debut = 0
+
+predebut = 0
+sexually_infrequent = 0
+adult_sexually_infrequent = 0
+youth_sexually_infrequent = 0
+adult_postdebut = 0
+youth_postdebut = 0
+
+for i in range(len(ppl)):
+    if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
+        all_women += 1
+        if ppl.method[i] != 0:
+            method_users += 1
+        if ppl.sexual_debut[i] == 0 and ppl.method[i] != 0:
+            use_before_debut += 1
+        if ppl.sexual_debut[i] == 0:
+            predebut += 1
+        if ppl.months_inactive[i] >= 12 and ppl.sexual_debut[i] == 1:
+            sexually_infrequent += 1
+        if ppl.months_inactive[i] >= 12 and ppl.sexual_debut[i] == 1 and ppl.age[i] >= 18:
+            adult_sexually_infrequent += 1
+        if ppl.months_inactive[i] >=12 and ppl.sexual_debut[i] == 1 and ppl.age[i] < 18:
+            youth_sexually_infrequent += 1
+        if ppl.sexual_debut[i] == 1 and ppl.age[i] >= 18:
+            adult_postdebut += 1
+        if ppl.sexual_debut[i] == 1 and ppl.age[i] < 18:
+            youth_postdebut += 1
+
+postdebut = all_women - predebut
+
+method_perc = method_users / all_women
+use_before_debut_perc = use_before_debut / all_women
+
+data_values = {'Method users': method_users,
+                'Women 15-49': all_women,
+                'Users before debut': use_before_debut
+               }
+
+data_percs =  {'CPR': method_users/all_women *100,
+                'Percent users not debuted': use_before_debut/method_users *100,
+                'CPR from non-debuters': use_before_debut/all_women *100
+               }
+
+data_sexually_infrequent = {'% 15-49 not yet': predebut/all_women *100,
+                            '% inact 12+ mo, deb': sexually_infrequent/postdebut * 100,
+                            '% inact 12+ mo, deb > 18': adult_sexually_infrequent/adult_postdebut * 100
+                            }
+
+
+per_frame = pd.DataFrame(data=data_percs, index=[0])
+infrequent_frame = pd.DataFrame (data=data_sexually_infrequent, index=[0])
+frame = pd.DataFrame({'Use':['All method users', 'Users before debut'], 'perc':[method_perc, use_before_debut_perc]})
+
+print(data_values)
+print(per_frame)
+print (infrequent_frame)
+print (f'% inact 12+ mo, deb < 18: {youth_sexually_infrequent/youth_postdebut * 100}')
+
+#ax = frame.plot.bar(x='Use', y='perc', rot=90)
+#ax.set_title('Method use before sexual debut - Senegal')
+
+#pl.show()
+
+sc.toc()

--- a/analyses/explore_method_use.py
+++ b/analyses/explore_method_use.py
@@ -16,7 +16,7 @@ min_age = 15
 do_plot_sim = False
 
 # Set up sim parameters
-pars = fp.pars(location='kenya')
+pars = fp.pars(location='senegal')
 pars['n_agents'] = 100_000 # Small population size
 
 sc.tic()
@@ -37,6 +37,7 @@ ppl = sim.people
 all_women = 0
 method_users = 0
 use_before_debut = 0
+use_while_inactive = 0
 
 predebut = 0
 sexually_infrequent = 0
@@ -57,9 +58,9 @@ for i in range(len(ppl)):
         if ppl.sexual_debut[i] == 0:
             predebut += 1
         if ppl.age[i] >= ppl.fated_debut[i]:
-            if ppl.sexual_debut[i] == 0:
-                time_to_debut.append(ppl.age[i] - ppl.fated_debut[i])
-            else:
+            #if ppl.sexual_debut[i] == 0:
+                #time_to_debut.append(ppl.age[i] - ppl.fated_debut[i])
+            if ppl.sexual_debut[i] == 1:
                 time_to_debut.append(ppl.sexual_debut_age[i] - ppl.fated_debut[i])
         if ppl.months_inactive[i] >= 12 and ppl.sexual_debut[i] == 1:
             sexually_infrequent += 1
@@ -71,6 +72,8 @@ for i in range(len(ppl)):
             adult_postdebut += 1
         if ppl.sexual_debut[i] == 1 and ppl.age[i] < 18:
             youth_postdebut += 1
+        if ppl.months_inactive[i] >= 12 and ppl.method[i] != 0:
+            use_while_inactive += 1
 
 postdebut = all_women - predebut
 
@@ -80,15 +83,18 @@ print(f'mean years from fated debut to first sex: {ttd.mean()}')
 
 method_perc = method_users / all_women
 use_before_debut_perc = use_before_debut / all_women
+use_while_inactive_perc = use_while_inactive / all_women
 
 data_values = {'Method users': method_users,
                 'Women 15-49': all_women,
-                'Users before debut': use_before_debut
+                'Users before debut': use_before_debut,
+                'Users while inactive': use_while_inactive
                }
 
 data_percs =  {'CPR': method_users/all_women *100,
                 'Percent users not debuted': use_before_debut/method_users *100,
                 'CPR from non-debuters': use_before_debut/all_women *100
+                #'CPR from inactive': use_while_inactive/all_women * 100
                }
 
 data_sexually_infrequent = {'% 15-49 not yet': predebut/all_women *100,

--- a/analyses/explore_method_use.py
+++ b/analyses/explore_method_use.py
@@ -45,6 +45,8 @@ youth_sexually_infrequent = 0
 adult_postdebut = 0
 youth_postdebut = 0
 
+time_to_debut = []
+
 for i in range(len(ppl)):
     if ppl.alive[i] and not ppl.sex[i] and ppl.age[i] >= min_age and ppl.age[i] < max_age:
         all_women += 1
@@ -54,6 +56,11 @@ for i in range(len(ppl)):
             use_before_debut += 1
         if ppl.sexual_debut[i] == 0:
             predebut += 1
+        if ppl.age[i] >= ppl.fated_debut[i]:
+            if ppl.sexual_debut[i] == 0:
+                time_to_debut.append(ppl.age[i] - ppl.fated_debut[i])
+            else:
+                time_to_debut.append(ppl.sexual_debut_age[i] - ppl.fated_debut[i])
         if ppl.months_inactive[i] >= 12 and ppl.sexual_debut[i] == 1:
             sexually_infrequent += 1
         if ppl.months_inactive[i] >= 12 and ppl.sexual_debut[i] == 1 and ppl.age[i] >= 18:
@@ -66,6 +73,10 @@ for i in range(len(ppl)):
             youth_postdebut += 1
 
 postdebut = all_women - predebut
+
+ttd = pl.asarray(time_to_debut)
+
+print(f'mean years from fated debut to first sex: {ttd.mean()}')
 
 method_perc = method_users / all_women
 use_before_debut_perc = use_before_debut / all_women

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -169,13 +169,16 @@ class timeseries_recorder(Analyzer):
         self.data = sc.objdict()
         return
 
+
     def initialize(self, sim):
         """
         Initializes self.keys from sim.people
         """
         super().initialize()
-        self.keys = sim.people.keys()
-        self.keys.remove('dobs')
+        self.keys = []
+        for key in sim.people.keys():
+            if sc.isarray(sim.people[key]):
+                self.keys.append(key)
         for key in self.keys:
             self.data[key] = []
         return
@@ -317,6 +320,7 @@ class verbose_sim(Analyzer):
             self.events::dict
                 Dictionary of events correponding to self.channels formatted as {timestep: channel: [indices]}.
         """
+        print('Warning, needs to be refactored to not use dataframes on each step')
         if not self.set_baseline:
             initial_pop = sim.pars['n_agents']
             self.last_year_births = [0] * initial_pop

--- a/fpsim/defaults.py
+++ b/fpsim/defaults.py
@@ -31,6 +31,7 @@ person_defaults = dict(
     short_interval       = 0,
     secondary_birth      = 0,
     pregnancies          = 0,
+    months_inactive      = 0,
     remainder_months     = 0,
     breastfeed_dur       = 0,
     breastfeed_dur_total = 0,

--- a/fpsim/locations/kenya.py
+++ b/fpsim/locations/kenya.py
@@ -63,6 +63,8 @@ def scalar_pars():
         'high_parity_nonuse': 1,
         'primary_infertility': 0.05,
         'exposure_factor': 1.0,  # Overall exposure correction factor
+        'restrict_method_use': 0, # If 1, only allows agents to select methods when sexually active within 12 months
+                                   # and at fated debut age.  Contraceptive matrix probs must be changed to turn on
 
         # MCPR
         'mcpr_growth_rate': 0.02,  # The year-on-year change in MCPR after the end of the data

--- a/fpsim/locations/senegal.py
+++ b/fpsim/locations/senegal.py
@@ -55,6 +55,8 @@ def scalar_pars():
         'high_parity_nonuse'     : 0.6,
         'primary_infertility'    : 0.05,
         'exposure_factor'        : 1.0, # Overall exposure correction factor
+        'restrict_method_use'    : 0,  # If 1, only allows agents to select methods when sexually active within 12 months
+                                       # and at fated debut age.  Contraceptive matrix probs must be changed to turn on
 
         # MCPR
         'mcpr_growth_rate'       : 0.02, # The year-on-year change in MCPR after the end of the data

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -909,7 +909,7 @@ class People(fpb.BasePeople):
         fecund = alive_now.filter((alive_now.sex == 0) * (alive_now.age < alive_now.pars['age_limit_fecundity']))
         nonpreg = fecund.filter(~fecund.pregnant)
         lact    = fecund.filter(fecund.lactating)
-        methods = nonpreg.filter(nonpreg.age >= self.pars['method_age'])
+        methods = nonpreg.filter((nonpreg.age >= nonpreg.fated_debut) * (nonpreg.months_inactive < 12))
 
         # Update everything else
         preg.update_pregnancy()  # Advance gestation in timestep, handle miscarriage

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -909,7 +909,10 @@ class People(fpb.BasePeople):
         fecund = alive_now.filter((alive_now.sex == 0) * (alive_now.age < alive_now.pars['age_limit_fecundity']))
         nonpreg = fecund.filter(~fecund.pregnant)
         lact    = fecund.filter(fecund.lactating)
-        methods = nonpreg.filter((nonpreg.age >= nonpreg.fated_debut) * (nonpreg.months_inactive < 12))
+        if self.pars['restrict_method_use'] == 1:
+            methods = nonpreg.filter((nonpreg.age >= nonpreg.fated_debut) * (nonpreg.months_inactive < 12))
+        else:
+            methods = nonpreg.filter(nonpreg.age >= self.pars['method_age'])
 
         # Update everything else
         preg.update_pregnancy()  # Advance gestation in timestep, handle miscarriage

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -72,7 +72,7 @@ class People(fpb.BasePeople):
         self.miscarriage      = arr(n, d['miscarriage']) # Number of miscarriages
         self.abortion         = arr(n, d['abortion']) # Number of abortions
         self.pregnancies      = arr(n, d['pregnancies']) #Number of conceptions (before abortion)
-        self.months_inactive  = arr(n, d['months_inactive'])
+        self.months_inactive  = arr(n, d['months_inactive']) # Number of months an agents has been sexually inactive once debuted
         self.postpartum       = arr(n, d['postpartum'])
         self.mothers          = arr(n, d['mothers'])
         self.short_interval   = arr(n, d['short_interval']) # Number of short birth intervals

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -72,6 +72,7 @@ class People(fpb.BasePeople):
         self.miscarriage      = arr(n, d['miscarriage']) # Number of miscarriages
         self.abortion         = arr(n, d['abortion']) # Number of abortions
         self.pregnancies      = arr(n, d['pregnancies']) #Number of conceptions (before abortion)
+        self.months_inactive  = arr(n, d['months_inactive'])
         self.postpartum       = arr(n, d['postpartum'])
         self.mothers          = arr(n, d['mothers'])
         self.short_interval   = arr(n, d['short_interval']) # Number of short birth intervals
@@ -326,6 +327,22 @@ class People(fpb.BasePeople):
         first_debut = non_pp.filter(now_active * never_sex)
         first_debut.sexual_debut = True
         first_debut.sexual_debut_age = first_debut.age
+
+        active_sex = self.sexually_active == 1
+        debuted = self.sexual_debut == 1
+        active = self.filter(active_sex * debuted)
+        inactive = self.filter(~active_sex * debuted)
+        active.months_inactive = 0
+        inactive.months_inactive += 1
+
+        inactive_year = self.months_inactive >= 12
+        sexually_infrequent = self.filter(inactive_year)
+
+        #print (f'Age: {sexually_infrequent.age}')
+        #print (f'Debuted?: {sexually_infrequent.sexual_debut}')
+        #print (f'Debut age: {sexually_infrequent.sexual_debut_age}')
+        #print (f'Months inactive: {sexually_infrequent.months_inactive}')
+        #print (f'On method?: {sexually_infrequent.method}')
 
         return
 

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -3,4 +3,4 @@
 #   pip install pytest-parallel
 
 export SCIRIS_BACKEND='agg' # Don't show plots
-pytest test_*.py --workers auto --durations=0
+pytest test_*.py -n auto --durations=0


### PR DESCRIPTION
This PR is the algorithm changes necessary to track sexual inactivity in agents and then select agents as eligible to start contraceptive methods based on whether they've gotten to age of sexual debut and have been sexually active within the last 12 months.   It adds a testing script under a new folder "analyses" to query the model for these characteristics.

The sexual activity tracker is ingrained in the model and the restriction can be turned on and off with a new boolean "restrict_method_use" in the location.py parameters files.  It is set to be off.  It should be turned on when matrices are substituted to be contraceptive method uptake only among women who have ever had sex and have had sex in the last 12 months. 

Closes issue #145.  Note that as requested by @MObrien-IDM, there is a very small non-zero chance that someone may take up a method before they debut (they are eligible at fated debut age, not just when they debut), but as the algorithm is written there is a zero chance they will take up a method if they have not had sex in >= 12 months.

CPR and other calibration targets for Senegal and Kenya will need to be queried again once matrices are swapped out.

### Type(s) of change
- [ ] Bugfix
- [X] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [X] Yes
  - [ ] N/A
- I've commented my code
  - [X] Yes
  - [ ] N/A
- I've incremented the version number
  - [X] Yes
  - [ ] N/A
- I've updated the changelog
  - [X] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [X] Yes
  - [ ] N/A