### PR TITLE
removed deprecated system packages option from RTD config, turned off…

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,6 @@ sphinx:
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:
-   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:
@@ -25,4 +24,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true


### PR DESCRIPTION
… PDF builds

### Brief description
https://github.com/InstituteforDiseaseModeling/idm-content/issues/44

Read the Docs is deprecating the "use system packages" build option and all requirements must be specified in requirements.txt. The system packages weren't necessary to build successfully. I also removed PDF builds, which can cause problems. 

### Type(s) of change
- [x] Bugfix
- [ ] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [ ] Yes
  - [ ] N/A
- I've commented my code
  - [ ] Yes
  - [ ] N/A
- I've incremented the version number
  - [ ] Yes
  - [ ] N/A
- I've updated the changelog
  - [ ] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [ ] Yes
  - [ ] N/A