### PR TITLE
Removing deprecated Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,6 @@ sphinx:
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:
-   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:
@@ -25,4 +24,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ sphinx:
    configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
+# formats:
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
### Brief description
https://github.com/InstituteforDiseaseModeling/idm-content/issues/44

Read the Docs is deprecating the "use system packages" configuration option at the end of the month. I also turned off PDF builds, which can cause problems. 

### Type(s) of change
- [x] Bugfix
- [ ] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [ ] Yes
  - [ ] N/A
- I've commented my code
  - [ ] Yes
  - [ ] N/A
- I've incremented the version number
  - [ ] Yes
  - [ ] N/A
- I've updated the changelog
  - [ ] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [ ] Yes
  - [ ] N/A