### PR TITLE
RTD updates to remove deprecated config options and add new Sphinx extensions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,26 @@ extensions = [
     'nbsphinx',
     'sphinx_search.extension', # search across multiple docsets in domain
     'sphinx.ext.viewcode', # link to view source code    
-    ]
+    'myst_parser', # source files written in MD or RST
+]
+
+myst_enable_extensions = [
+    "amsmath",
+    "attrs_inline",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "inv_link",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]
 
 autodoc_default_options = {
     'member-order': 'bysource',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,12 @@ html_favicon = "images/favicon.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+
 html_static_path = ['_static']
+
+html_css_files = ['theme_overrides.css']
+
+html_js_files = ['show_block_by_os.js'] 
 
 html_context = {
     'rtd_url': 'https://docs.idmod.org/projects/fpsim/en/latest',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',  # Add a link to the Python source code for classes, functions etc.
     'nbsphinx',
+    'sphinx_search.extension', # search across multiple docsets in domain
 ]
 
 autodoc_default_options = {
@@ -156,6 +157,21 @@ html_show_sphinx = False
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
 html_use_opensearch = 'docs.idmod.org/projects/fpsim/en/latest'
+
+# -- RTD Sphinx search for searching across the entire domain, default child -------------
+
+if os.environ.get('READTHEDOCS') == 'True':
+
+    search_project_parent = "institute-for-disease-modeling-idm"
+    search_project = os.environ["READTHEDOCS_PROJECT"]
+    search_version = os.environ["READTHEDOCS_VERSION"]
+
+    rtd_sphinx_search_default_filter = f"subprojects:{search_project}/{search_version}"
+
+    rtd_sphinx_search_filters = {
+        "Search this project": f"project:{search_project}/{search_version}",
+        "Search all IDM docs": f"subprojects:{search_project_parent}/{search_version}",
+    }
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'FPsim'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,8 @@ extensions = [
     'sphinx.ext.viewcode',  # Add a link to the Python source code for classes, functions etc.
     'nbsphinx',
     'sphinx_search.extension', # search across multiple docsets in domain
-]
+    'sphinx.ext.viewcode', # link to view source code    
+    ]
 
 autodoc_default_options = {
     'member-order': 'bysource',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,6 @@ myst_enable_extensions = [
     "fieldlist",
     "html_admonition",
     "html_image",
-    "inv_link",
     "linkify",
     "replacements",
     "smartquotes",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,6 @@ nbsphinx
 pandoc
 pypandoc
 optuna
+myst-parser
+readthedocs-sphinx-search
+jupyterlab


### PR DESCRIPTION
### Brief description
Commit comments link to the tickets in the idm-content repo for Sphinx/Read the Docs infrastructure. Removed deprecated doc build config options, added improved search and myst extension to write source files in RST or Markdown. Updated packages used to build docs. 

### Type(s) of change
- [x] Bugfix
- [ ] Refactor
- [x] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [ ] Yes
  - [ ] N/A
- I've commented my code
  - [ ] Yes
  - [ ] N/A
- I've incremented the version number
  - [ ] Yes
  - [ ] N/A
- I've updated the changelog
  - [ ] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [ ] Yes
  - [ ] N/A