### PR TITLE
Empowerment results

### DIFF
--- a/examples/education_microsim.py
+++ b/examples/education_microsim.py
@@ -1,0 +1,29 @@
+'''
+Simple and small simulation using education analyzer
+'''
+
+import sciris as sc
+import fpsim as fp
+import matplotlib.pyplot as plt
+
+# Set options
+do_plot = True
+pars = fp.pars(location='kenya')
+pars['n_agents'] = 50 # Small population size
+
+
+
+sc.tic()
+sim = fp.Sim(pars=pars, analyzers=[fp.education_recorder()])
+sim.run()
+
+if do_plot:
+    edu_analyzer= sim.get_analyzers()[0]
+    #Plot a subset of the the available trajectories for female individuals
+    for idx in range(edu_analyzer.max_pop_size//8):
+        edu_analyzer.plot(index=idx)
+    edu_analyzer.plot_waterfall()
+    plt.show()
+
+sc.toc()
+print('Done.')

--- a/examples/education_microsim.py
+++ b/examples/education_microsim.py
@@ -20,8 +20,8 @@ sim.run()
 if do_plot:
     edu_analyzer= sim.get_analyzers()[0]
     #Plot a subset of the the available trajectories for female individuals
-    # for idx in range(edu_analyzer.max_pop_size//8):
-    #     edu_analyzer.plot(index=idx)
+    for idx in range(max(2, edu_analyzer.max_agents//8)):
+        edu_analyzer.plot(index=idx)
     edu_analyzer.plot_waterfall()
     plt.show()
 

--- a/examples/education_microsim.py
+++ b/examples/education_microsim.py
@@ -20,8 +20,8 @@ sim.run()
 if do_plot:
     edu_analyzer= sim.get_analyzers()[0]
     #Plot a subset of the the available trajectories for female individuals
-    for idx in range(edu_analyzer.max_pop_size//8):
-        edu_analyzer.plot(index=idx)
+    # for idx in range(edu_analyzer.max_pop_size//8):
+    #     edu_analyzer.plot(index=idx)
     edu_analyzer.plot_waterfall()
     plt.show()
 

--- a/examples/example_empowerment_microsim.py
+++ b/examples/example_empowerment_microsim.py
@@ -4,6 +4,7 @@ Simple simulation using the new empowement related attributes
 
 import sciris as sc
 import fpsim as fp
+import matplotlib.pyplot as plt
 
 # Set options
 do_plot = True
@@ -13,14 +14,14 @@ pars['n_agents'] = 500 # Small population size
 
 
 sc.tic()
-sim = fp.Sim(pars=pars, analyzers=fp.empowerment_recorder())
+sim = fp.Sim(pars=pars, analyzers=fp.empowerment_recorder(bins=[0, 15, 20, 40, 50, 100]))
 sim.run()
 
 if do_plot:
     sim.plot()
     empwr_analyzer= sim.get_analyzers()[0]
-    empwr_analyzer.plot(data_args=['edu_objective'])
-    import  ipdb; ipdb.set_trace()
+    empwr_analyzer.plot()
+    plt.show()
 
 sc.toc()
 print('Done.')

--- a/examples/example_empowerment_microsim.py
+++ b/examples/example_empowerment_microsim.py
@@ -10,12 +10,17 @@ do_plot = True
 pars = fp.pars(location='kenya')
 pars['n_agents'] = 500 # Small population size
 
+
+
 sc.tic()
-sim = fp.Sim(pars=pars)
+sim = fp.Sim(pars=pars, analyzers=fp.empowerment_recorder())
 sim.run()
 
 if do_plot:
     sim.plot()
+    empwr_analyzer= sim.get_analyzers()[0]
+    empwr_analyzer.plot(data_args=['edu_objective'])
+    import  ipdb; ipdb.set_trace()
 
 sc.toc()
 print('Done.')

--- a/examples/example_empowerment_microsim.py
+++ b/examples/example_empowerment_microsim.py
@@ -5,7 +5,7 @@ Simple simulation using the new empowement related attributes
 import sciris as sc
 import fpsim as fp
 import matplotlib.pyplot as plt
-
+import numpy as np
 # Set options
 do_plot = True
 pars = fp.pars(location='kenya')
@@ -14,7 +14,8 @@ pars['n_agents'] = 500 # Small population size
 
 
 sc.tic()
-sim = fp.Sim(pars=pars, analyzers=fp.empowerment_recorder(bins=[0, 15, 20, 40, 50, 100]))
+age_bins = np.arange(100)[::5] # 5 year bins
+sim = fp.Sim(pars=pars, analyzers=[fp.empowerment_recorder(bins=age_bins)])
 sim.run()
 
 if do_plot:

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -247,7 +247,7 @@ class education_recorder(Analyzer):
             self.keys = ['edu_objective', 'edu_attainment', 'edu_completed',
                          'edu_dropout', 'edu_interrupted',
                          'pregnant', 'alive', 'age']
-            self.max_pop_size = 0   # keep track of the maximum size of the population
+            self.max_agents = 0     # maximum number of agents this analyzer tracks
             self.time = []
             self.trajectories = {}  # Store education trajectories
             return
@@ -261,7 +261,7 @@ class education_recorder(Analyzer):
             self.snapshots[str(sim.i)] = {}
             for key in self.keys:
                 self.snapshots[str(sim.i)][key] = sc.dcp(females[key])  # Take snapshot!
-                self.max_pop_size = max(self.max_pop_size, len(females))
+                self.max_agents = max(self.max_agents, len(females))
             return
 
         def finalize(self, sim=None):
@@ -274,7 +274,7 @@ class education_recorder(Analyzer):
             # Process data so we can plot it easily
             self.time = np.array([key for key in self.snapshots.keys()], dtype=int)
             for state in self.keys:
-                self.trajectories[state] = np.full((len(self.time), self.max_pop_size), np.nan)
+                self.trajectories[state] = np.full((len(self.time), self.max_agents), np.nan)
                 for ti, t in enumerate(self.time):
                     stop_idx = len(self.snapshots[t][state])
                     self.trajectories[state][ti, 0:stop_idx] = self.snapshots[t][state]

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -444,7 +444,7 @@ class empowerment_recorder(Analyzer):
         super().__init__()
         self.bins = bins
         self.data = sc.objdict()
-        self.keys = ['partnered', 'urban', 'paid_employment', 'control_over_wages', 'sexual_autonomy', 'age']
+        self.keys = ['partnered', 'urban', 'paid_employment', 'decision_wages', 'decision_health', 'sexual_autonomy', 'age']
         self.nbins = None
         return
 

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -307,6 +307,7 @@ class education_recorder(Analyzer):
             pl.ylim([0, 24])
             pl.title('Education')
             pl.ylabel('Education (years)')
+            pl.xlabel('Timesteps')
             pl.legend()
 
             k += 1
@@ -326,14 +327,21 @@ class education_recorder(Analyzer):
                     plt.step(self.time, 4*data[:, index],  color="black", ls="--", label=f"{state}", where='mid', **pl_args)
                 pl.title(f"Education trajectories - Start age: {int(age_data[0, index])}; final age {int(age_data[-1, index])}.")
                 pl.ylabel('State')
+                pl.xlabel('Timesteps')
                 pl.legend()
             return fig
 
 
-        def plot_waterfall(self, max_timepoints=30, fig_args=None, pl_args=None):
+        def plot_waterfall(self, max_timepoints=30, min_age=18, fig_args=None, pl_args=None):
             from scipy.stats import gaussian_kde
             data_att = self.trajectories["edu_attainment"]
             data_obj = self.trajectories["edu_objective"]
+            data_age = self.trajectories["age"]
+
+            mask = data_age < min_age
+            data_att = np.ma.array(data_att, mask=mask, fill_value=np.nan)
+            data_obj = np.ma.array(data_obj, mask=mask, fill_value=np.nan)
+
 
             n_tpts = data_att.shape[0]
             if n_tpts <= max_timepoints:

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -330,8 +330,25 @@ class education_recorder(Analyzer):
                 pl.legend()
             return fig
 
+        def plot_waterfall(self, max_timepoints=30, min_age=18, max_age=40, fig_args=None, pl_args=None):
+            """
+            Plot a waterfall plot showing the evolution of education objective and attainment over time
+            for a specified age group.
 
-        def plot_waterfall(self, max_timepoints=30, min_age=18, max_age=20, fig_args=None, pl_args=None):
+            Args:
+                max_timepoints (int, optional): The maximum number of timepoints to plot, defaults to 30.
+                min_age (int, optional): The minimum age for the age group, defaults to 18.
+                max_age (int, optional): The maximum age for the age group, defaults to 20.
+
+            Returns:
+                figure handle
+
+            The function generates uses kernel density estimation to visualize the data. If there's not data for the
+            min max age specified, for a specific time step (ie, there are no agents in that age group), it adds a
+            textbox. This is an edge case that can happen for a simulation with very few agents, and a very narrow
+            age group.
+            """
+
             from scipy.stats import gaussian_kde
 
             data_att = self.trajectories["edu_attainment"]
@@ -395,8 +412,6 @@ class education_recorder(Analyzer):
                     ax.annotate('No data available ', xy=(edu_mid, y_scaling*idx), xycoords='data', fontsize=8,
                                 ha='center', va='center', bbox=dict(boxstyle='round,pad=0.4', fc='none', ec="none"))
 
-
-
             # Labels and annotations
             ax.set_xlim([edu_min, edu_max])
             ax.set_xlabel('Education years')
@@ -404,11 +419,9 @@ class education_recorder(Analyzer):
             ax.legend()
             ax.set_title(f"Evolution of education \n objective and attainment for age group:\n{min_age}-{max_age}.")
 
-
             # Show the plot
             plt.show()
-
-
+            return fig
 
 
 class empowerment_recorder(Analyzer):

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -12,10 +12,9 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from . import defaults as fpd
 
-
 #%% Generic intervention classes
 
-__all__ = ['Analyzer', 'snapshot', 'timeseries_recorder', 'age_pyramids', 'verbose_sim', 'empowerment_recorder']
+__all__ = ['Analyzer', 'snapshot', 'timeseries_recorder', 'age_pyramids', 'verbose_sim', 'empowerment_recorder', 'education_recorder']
 
 
 class Analyzer(sc.prettyobj):
@@ -233,7 +232,102 @@ class timeseries_recorder(Analyzer):
 
 
 class education_recorder(Analyzer):
-    pass
+        '''
+        Analyzer records all education attributes of females + pregnancy + living status
+        for all timesteps. Made for debugging purposes.
+
+        Args:
+            args   (list): additional timestep(s)
+            kwargs (dict): passed to Analyzer()
+        '''
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)   # Initialize the Analyzer object
+            self.snapshots = sc.odict()  # Store the actual snapshots
+            self.keys = ['edu_objective', 'edu_attainment',
+                         'edu_dropout', 'edu_interrupted', 'edu_completed',
+                         'pregnant', 'alive']
+            self.max_pop_size = 0   # keep track of the maximum size of the population
+            self.time = []
+            self.trajectories = {}  # Store education trajectories
+            return
+
+        def apply(self, sim):
+            """
+            Apply snapshot at each timestep listed in timesteps and
+            save result at snapshot[str(timestep)]
+            """
+            females = sim.people.filter(sim.people.is_female)
+            self.snapshots[str(sim.i)] = {}
+            for key in self.keys:
+                self.snapshots[str(sim.i)][key] = sc.dcp(females[key])  # Take snapshot!
+                self.max_pop_size = max(self.max_pop_size, len(females))
+            return
+
+        def finalize(self, sim=None):
+            """
+             Process data in snapshots so we can plot it easily
+            """
+            if self.finalized:
+                raise RuntimeError(
+                    'Analyzer already finalized')  # Raise an error because finalizing multiple times has a high probability of producing incorrect results e.g. applying rescale factors twice
+            self.finalized = True
+            # Process data so we can plot it easily
+            self.time = np.array([key for key in self.snapshots.keys()], dtype=int)
+            for state in self.keys:
+                self.trajectories[state] = np.full((len(self.time), self.max_pop_size), np.nan)
+                for ti, t in enumerate(self.time):
+                    stop_idx = len(self.snapshots[t][state])
+                    self.trajectories[state][ti, 0:stop_idx] = self.snapshots[t][state]
+            return
+
+        def plot(self, inds=[0], fig_args=None, pl_args=None):
+            """
+            Plots time series of each state as a line graph
+            Args:
+               inds: indices of agents to plot
+            """
+            fig_args = sc.mergedicts(fig_args)
+            pl_args = sc.mergedicts(pl_args)
+            rows, cols = sc.get_rows_cols(2)
+
+            fig = pl.figure(**fig_args)
+            keys2 = ['edu_completed', 'edu_interrupted', 'edu_dropout']
+            keys3 = ['pregnant', 'alive']
+
+            k = 0
+            pl.subplot(rows, cols, k + 1)
+
+            state = "edu_attainment"
+            data = self.trajectories[state]
+            pl.step(self.time, data[:, inds], color="black", label=f"{state}", where='mid', **pl_args)
+            state = "edu_objective"
+            data = self.trajectories[state]
+            pl.step(self.time, data[:, inds], color="red", ls="--", label=f"{state}", where='mid', **pl_args)
+            pl.ylim([0, 24])
+            pl.title('Education')
+            pl.ylabel('Education (years)')
+            pl.legend()
+
+            k += 1
+            for state in sc.mergelists(keys2, keys3):
+                pl.subplot(rows, cols, k + 1)
+                data = self.trajectories[state]
+                if state in keys2:
+                    if state  == 'edu_interrupted':
+                        pl.step(self.time, 3*data[:, inds], color=[0.7, 0.7, 0.7], label=f"{state}", ls=":", where='mid', **pl_args)
+                    elif state == "edu_dropout":
+                        pl.step(self.time, 3*data[:, inds], color="black", label=f"{state}", ls=":", where='mid', **pl_args)
+                    else:
+                        pl.step(self.time, 3*data[:, inds], color="#2ca25f", label=f"{state}", where='mid', **pl_args)
+                elif state  == 'pregnant':
+                    pl.step(self.time, data[:, inds], color="#dd1c77", label=f"{state}", where='mid', **pl_args)
+                elif state == 'alive':
+                    plt.step(self.time, 4*data[:, inds],  color="black", ls="--", label=f"{state}", where='mid', **pl_args)
+                pl.title('Education')
+                pl.ylabel('State')
+                pl.legend()
+            return fig
 
 
 class empowerment_recorder(Analyzer):
@@ -287,7 +381,7 @@ class empowerment_recorder(Analyzer):
             if key == 'age':
                 # Count how many living females we have in this age group
                 temp = np.histogram(ages, self.bins)[0]
-                vals = temp / temp.sum() # Transform to density
+                vals = temp / temp.sum()  # Transform to density
             elif key in ['partnered', 'urban', 'paid_employment']:
                 vals = [np.mean(data[age_group == group_idx]) for group_idx in range(1, len(self.bins))]
             else:  # assume float

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -281,11 +281,11 @@ class education_recorder(Analyzer):
                     self.trajectories[state][ti, 0:stop_idx] = self.snapshots[t][state]
             return
 
-        def plot(self, inds=[0], fig_args=None, pl_args=None):
+        def plot(self, index=0, fig_args=None, pl_args=None):
             """
             Plots time series of each state as a line graph
             Args:
-               inds: indices of agents to plot
+               index: index of the female individual, must be less the analyzer's max_pop_size
             """
             fig_args = sc.mergedicts(fig_args)
             pl_args = sc.mergedicts(pl_args)
@@ -300,10 +300,10 @@ class education_recorder(Analyzer):
 
             state = "edu_attainment"
             data = self.trajectories[state]
-            pl.step(self.time, data[:, inds], color="black", label=f"{state}", where='mid', **pl_args)
+            pl.step(self.time, data[:, index], color="black", label=f"{state}", where='mid', **pl_args)
             state = "edu_objective"
             data = self.trajectories[state]
-            pl.step(self.time, data[:, inds], color="red", ls="--", label=f"{state}", where='mid', **pl_args)
+            pl.step(self.time, data[:, index], color="red", ls="--", label=f"{state}", where='mid', **pl_args)
             pl.ylim([0, 24])
             pl.title('Education')
             pl.ylabel('Education (years)')
@@ -315,15 +315,15 @@ class education_recorder(Analyzer):
                 data = self.trajectories[state]
                 if state in keys2:
                     if state  == 'edu_interrupted':
-                        pl.step(self.time, 3*data[:, inds], color=[0.7, 0.7, 0.7], label=f"{state}", ls=":", where='mid', **pl_args)
+                        pl.step(self.time, 3*data[:, index], color=[0.7, 0.7, 0.7], label=f"{state}", ls=":", where='mid', **pl_args)
                     elif state == "edu_dropout":
-                        pl.step(self.time, 3*data[:, inds], color="black", label=f"{state}", ls=":", where='mid', **pl_args)
+                        pl.step(self.time, 3*data[:, index], color="black", label=f"{state}", ls=":", where='mid', **pl_args)
                     else:
-                        pl.step(self.time, 3*data[:, inds], color="#2ca25f", label=f"{state}", where='mid', **pl_args)
+                        pl.step(self.time, 3*data[:, index], color="#2ca25f", label=f"{state}", where='mid', **pl_args)
                 elif state  == 'pregnant':
-                    pl.step(self.time, data[:, inds], color="#dd1c77", label=f"{state}", where='mid', **pl_args)
+                    pl.step(self.time, data[:, index], color="#dd1c77", label=f"{state}", where='mid', **pl_args)
                 elif state == 'alive':
-                    plt.step(self.time, 4*data[:, inds],  color="black", ls="--", label=f"{state}", where='mid', **pl_args)
+                    plt.step(self.time, 4*data[:, index],  color="black", ls="--", label=f"{state}", where='mid', **pl_args)
                 pl.title('Education')
                 pl.ylabel('State')
                 pl.legend()

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -160,7 +160,7 @@ class timeseries_recorder(Analyzer):
         self.data: A dictionary where self.data[state][timestep] is the mean of the state at that timestep.
     '''
 
-    def __init__(self):
+    def __init__(self, to_record=None):
         """
         Initializes self.i/t/y as empty lists and self.data as empty dictionary
         """
@@ -169,6 +169,8 @@ class timeseries_recorder(Analyzer):
         self.t = []
         self.y = []
         self.data = sc.objdict()
+        self.keys = to_record
+        self.to_record = []
         return
 
 
@@ -177,10 +179,12 @@ class timeseries_recorder(Analyzer):
         Initializes self.keys from sim.people
         """
         super().initialize()
-        self.keys = []
-        for key in sim.people.keys():
+        if self.keys is None:
+            self.keys = sim.people.keys()
+
+        for key in self.keys:
             if sc.isarray(sim.people[key]):
-                self.keys.append(key)
+                self.to_record.append(key)
         for key in self.keys:
             self.data[key] = []
         return
@@ -193,7 +197,7 @@ class timeseries_recorder(Analyzer):
         self.i.append(sim.i)
         self.t.append(sim.t)
         self.y.append(sim.y)
-        for k in self.keys:
+        for k in self.to_record:
             val = np.mean(sim.people[k])
             self.data[k].append(val)
 

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -287,7 +287,7 @@ class education_recorder(Analyzer):
             Args:
                index: index of the female individual, must be less the analyzer's max_pop_size
             """
-            fig_args = sc.mergedicts(fig_args)
+            fig_args = sc.mergedicts(fig_args, {'figsize': (5, 7)})
             pl_args = sc.mergedicts(pl_args)
             rows, cols = sc.get_rows_cols(2)
 


### PR DESCRIPTION
### Brief description
This PR implements two new analyzers to visualize empowerment and education results. 

Let me know if you want to update/change anything (labels, default colours, layout of plots, etc)

### Empowerment analyzer
Plots time vs age groups (that can be specified).

![Screenshot from 2023-11-02 06-43-27](https://github.com/fpsim/fpsim/assets/1563810/ba0b3b5e-57df-44ee-8809-2d2814d838af)


### Education analyzer
This analyzer can generate two plots
 ##### Individual education trajectories
![Screenshot from 2023-11-02 07-13-49](https://github.com/fpsim/fpsim/assets/1563810/a345016c-d4d0-44fa-a191-6b41bb34e23f)
![Screenshot from 2023-11-02 07-13-55](https://github.com/fpsim/fpsim/assets/1563810/95cb6849-b852-4983-b126-77fa9eeba955)


##### Waterfall plot
Shows the evolution of two education distributions: education goal distribution, & and education attainment distribution (ie, current level of education attained). Education data can be filtered by min and max ages of agents.

![Screenshot from 2023-11-02 06-39-58](https://github.com/fpsim/fpsim/assets/1563810/33822e05-46b3-466a-9861-a4522bf12b4a)




### Type(s) of change
- [ ] Bugfix
- [ ] Refactor
- [x] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [x] Yes
  - [ ] N/A
- I've commented my code
  - [x] Yes
  - [ ] N/A
- I've incremented the version number
  - [ ] Yes
  - [ ] N/A
- I've updated the changelog
  - [ ] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [x] Yes, added example sims that call the analyzers
  - [ ] N/A