### PR TITLE
Add weights for method mix

### DIFF
--- a/examples/calibration_scripts/calibrate_simple.py
+++ b/examples/calibration_scripts/calibrate_simple.py
@@ -41,6 +41,7 @@ country = 'kenya'
 
 # Set options for plotting
 do_plot_sim = False
+do_plot_by_age = True
 do_plot_asfr = True
 do_plot_methods = True
 do_plot_ageparity = False
@@ -77,17 +78,6 @@ data_tfr     = pd.read_csv(os.path.join(country_dir, 'data/tfr.csv'))
 data_popsize = pd.read_csv(os.path.join(country_dir, 'data/popsize.csv'))
 
 # Set up global variables
-age_bin_map = {
-        '10-14': [10, 15],
-        '15-19': [15, 20],
-        '20-24': [20, 25],
-        '25-29': [25, 30],
-        '30-34': [30, 35],
-        '35-39': [35, 40],
-        '40-44': [40, 45],
-        '45-49': [45, 50]
-}
-
 min_age = 15
 max_age = 50
 bin_size = 5
@@ -103,45 +93,45 @@ pars['end_year'] = 2020  # 1961 - 2020 is the normal date range
 
 # Free parameters for calibration
 pars['fecundity_var_low'] = 1
-pars['fecundity_var_high'] = 1.27
-pars['exposure_factor'] = 1.93
-pars['high_parity'] = 1.04
-pars['high_parity_nonuse'] = .88
+pars['fecundity_var_high'] = 1.80
+pars['exposure_factor'] = 1.23 #1.93
 '''
 freepars = dict(
         fecundity_var_low=[0.95, 0.925, 1.0],
         fecundity_var_high=[1.1, 1.025, 1.3],
         exposure_factor=[2.0, 0.9, 2.2],
-        high_parity=[1.0, 0.95, 1.2],
-        high_parity_nonuse=[.8, 0.7, 1.0]
 )
 '''
-# Last free parameter, postpartum sexual activity correction or 'birth spacing preference'
-# Set all to 1 to reset
-spacing_pars = {'space0_6': 1, 'space18_24': 1, 'space27_36': 1, 'space9_15': 1}  # output from 'optimize-space-prefs-{country}.py'
-pars['spacing_pref']['preference'][:3] = spacing_pars['space0_6']
-pars['spacing_pref']['preference'][3:6] = spacing_pars['space9_15']
-pars['spacing_pref']['preference'][6:9] = spacing_pars['space18_24']
-#pars['spacing_pref']['preference'][9:] = spacing_pars['space27_36'] # Removing this bin for Kenya as it doesn't extend out
-
-# Only other free parameters are age-based exposure and parity-based exposure, can adjust manually in {country}.py
-
-# Print out free params being used
-print("FREE PARAMETERS BEING USED:")
-print(f"Fecundity range: {pars['fecundity_var_low']}-{pars['fecundity_var_high']}")
-print(f"Exposure factor: {pars['exposure_factor']}")
-print(f"High parity: {pars['high_parity']}")
-print(f"High parity, nonuse: {pars['high_parity_nonuse']}")
-#print(f"Birth spacing preference: {spacing_pars}")
-print(f"Age-based exposure and parity-based exposure can be adjusted manually in {country}.py")
+# # Last free parameter, postpartum sexual activity correction or 'birth spacing preference'
+# # Set all to 1 to reset
+# # spacing_pars = {'space0_6': 1, 'space18_24': 1, 'space27_36': 1, 'space9_15': 1}  # output from 'optimize-space-prefs-{country}.py'
+# # pars['spacing_pref']['preference'][:3] = spacing_pars['space0_6']
+# # pars['spacing_pref']['preference'][3:6] = spacing_pars['space9_15']
+# # pars['spacing_pref']['preference'][6:9] = spacing_pars['space18_24']
+# #pars['spacing_pref']['preference'][9:] = spacing_pars['space27_36'] # Removing this bin for Kenya as it doesn't extend out
+#
+# # Only other free parameters are age-based exposure and parity-based exposure, can adjust manually in {country}.py
+#
+# # Print out free params being used
+# print("FREE PARAMETERS BEING USED:")
+# print(f"Fecundity range: {pars['fecundity_var_low']}-{pars['fecundity_var_high']}")
+# print(f"Exposure factor: {pars['exposure_factor']}")
+# #print(f"Birth spacing preference: {spacing_pars}")
+# print(f"Age-based exposure and parity-based exposure can be adjusted manually in {country}.py")
 
 #calibration = fp.Calibration(pars, calib_pars=freepars)
 #calibration.calibrate()
 #pars.update(calibration.best_pars)
 
-# Run the sim
-method_choice = fp.SimpleChoice(location='kenya')
-sim = fp.Sim(pars=pars, contraception_module=method_choice)
+# Adjust contraceptive choice parameters
+cm_pars = dict(
+    prob_use_year=2020,
+    prob_use_trend_par=0.03,
+    force_choose=False,
+    method_weights=np.array([0.35, .8, 0.5, 0.8, 1.3, 1, 1.8, 0.5, 8])
+)
+method_choice = fp.SimpleChoice(pars=cm_pars, location='kenya')
+sim = fp.Sim(pars=pars, contraception_module=method_choice, analyzers=[fp.cpr_by_age(), fp.method_mix_by_age()])
 sim.run()
 
 # Plot results from sim run
@@ -158,6 +148,32 @@ ppl = sim.people
 data_dict = {}
 model_dict = {} # For comparison from model to data
 
+if do_plot_by_age:
+    fig, ax = pl.subplots()
+    age_bins = [18, 20, 25, 35, 50]
+    colors = sc.vectocolor(age_bins)
+    cind = 0
+
+    for alabel, ares in sim.get_analyzer('cpr_by_age').results.items():
+        ax.plot(sim.results.t, ares, label=alabel, color=colors[cind])
+        cind += 1
+    ax.legend(loc='best', frameon=False)
+    ax.set_ylim([0, 1])
+    ax.set_ylabel('CPR')
+    ax.set_title('CPR')
+    if do_save:
+        sc.savefig(os.path.join(figs_dir, 'cpr_by_age.png'))
+    pl.show()
+
+    fig, ax = pl.subplots()
+    df = pd.DataFrame(sim.get_analyzer('method_mix_by_age').results)
+    df['method'] = sim.contraception_module.methods.keys()
+    df_plot = df.melt(id_vars='method')
+    sns.barplot(x=df_plot['method'], y=df_plot['value'], ax=ax, hue=df_plot['variable'], palette="viridis")
+    if do_save:
+        sc.savefig(os.path.join(figs_dir, 'method_mix_by_age.png'))
+    pl.show()
+
 
 def pop_growth_rate(years, population):
         '''
@@ -172,6 +188,7 @@ def pop_growth_rate(years, population):
 
         return growth_rate
 
+
 # Start series of options for plotting data to model comaprisons
 if do_plot_asfr:
         '''
@@ -179,7 +196,7 @@ if do_plot_asfr:
         '''
         pl.clf()
         # Print ASFR form model in output
-        for key in age_bin_map.keys():
+        for key in fp.age_bin_map.keys():
             print(f'ASFR (annual) for age bin {key} in the last year of the sim: {res["asfr"][key][-1]}')
 
         x = [1, 2, 3, 4, 5, 6, 7, 8]
@@ -192,7 +209,7 @@ if do_plot_asfr:
         asfr_model = []
 
         # Extract from model
-        for key in age_bin_map.keys():
+        for key in fp.age_bin_map.keys():
                 x_labels.append(key)
                 asfr_model.append(res['asfr'][key][-1])
 
@@ -300,7 +317,7 @@ if do_plot_ageparity:
         pl.clf()
 
         # Set up
-        age_keys = list(age_bin_map.keys())[1:]
+        age_keys = list(fp.age_bin_map.keys())[1:]
         age_bins = pl.arange(min_age, max_age, bin_size)
         parity_bins = pl.arange(0, 7) # Plot up to parity 6
         n_age = len(age_bins)

--- a/fpsim/__init__.py
+++ b/fpsim/__init__.py
@@ -14,3 +14,4 @@ from .scenarios import *
 from .education import *
 from .empowerment import *
 
+

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -13,7 +13,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 #%% Generic intervention classes
 
-__all__ = ['Analyzer', 'snapshot', 'cpr_by_age', 'age_pyramids', 'empowerment_recorder', 'education_recorder']
+__all__ = ['Analyzer', 'snapshot', 'cpr_by_age', 'method_mix_by_age', 'age_pyramids', 'empowerment_recorder', 'education_recorder']
 
 
 class Analyzer(sc.prettyobj):
@@ -170,6 +170,29 @@ class cpr_by_age(Analyzer):
         self.total[sim.ti] = sc.safedivide(np.count_nonzero(total_num_conds), np.count_nonzero(total_denom_conds))
         return
 
+
+class method_mix_by_age(Analyzer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)   # Initialize the Analyzer object
+        self.age_bins = [v[1] for v in fpd.method_age_map.values()]
+        self.results = None
+        self.n_methods = None
+        return
+
+    def initialize(self, sim):
+        super().initialize()
+
+    def finalize(self, sim):
+        n_methods = len(sim.contraception_module.methods)
+        self.results = {k: np.zeros(n_methods) for k in fpd.method_age_map.keys()}
+        ppl = sim.people
+        for key, (age_low, age_high) in fpd.method_age_map.items():
+            match_low_high = fpu.match_ages(ppl.age, age_low, age_high)
+            denom_conds = match_low_high * (ppl.sex == 0) * ppl.alive
+            for mn in range(n_methods):
+                num_conds = denom_conds * (ppl.method == mn)
+                self.results[key][mn] = sc.safedivide(np.count_nonzero(num_conds), np.count_nonzero(denom_conds))
+        return
 
 class education_recorder(Analyzer):
         '''

--- a/fpsim/base.py
+++ b/fpsim/base.py
@@ -319,9 +319,9 @@ class BasePeople(sc.prettyobj):
         '''
 
         # Create a new People object with the same properties as the original
-        filtered = object.__new__(self.__class__) # Create a new People instance
-        BasePeople.__init__(filtered) # Perform essential initialization
-        filtered.__dict__ = self.__dict__.copy() # Copy pointers to the arrays in People
+        filtered = object.__new__(self.__class__)  # Create a new People instance
+        BasePeople.__init__(filtered)  # Perform essential initialization
+        filtered.__dict__ = self.__dict__.copy()  # Copy pointers to the arrays in People
 
         # Perform the filtering
         if criteria is None: # No filtering: reset

--- a/fpsim/locations/ethiopia/ethiopia.py
+++ b/fpsim/locations/ethiopia/ethiopia.py
@@ -22,7 +22,6 @@ def scalar_pars():
         'breastfeeding_dur_beta': 8.20149079,   # Location parameter of gumbel distribution. Requires children's recode DHS file, see data_processing/breastfeedin_stats.R
         'abortion_prob':        0.176,          # From https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5568682/, % of all pregnancies calculated
         'twins_prob':           0.011,          # From https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0025239
-        'mcpr_norm_year':       2020,           # Year to normalize MCPR trend to 1
     }
     return scalar_pars
 

--- a/fpsim/locations/kenya/kenya.py
+++ b/fpsim/locations/kenya/kenya.py
@@ -21,8 +21,6 @@ def scalar_pars():
         'breastfeeding_dur_beta': 7.5435309020483,  # Location parameter of gumbel distribution. Requires children's recode DHS file, see data_processing/breastfeedin_stats.R
         'abortion_prob':        0.201,              # From https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-015-0621-1, % of all pregnancies calculated
         'twins_prob':           0.016,              # From https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0025239
-        'high_parity_nonuse':   1,                  # TODO: check whether it's correct that this should be different to the other locations
-        'mcpr_norm_year':       2020,               # Year to normalize MCPR trend to 1
     }
     return scalar_pars
 

--- a/fpsim/locations/kenya/kenya.py
+++ b/fpsim/locations/kenya/kenya.py
@@ -921,7 +921,7 @@ def process_dur_use(methods):
     df = pd.read_csv(thisdir / 'data' / 'method_time_coefficients.csv', keep_default_na=False, na_values=['NaN'])
     for method in methods.values():
         if method.name == 'btl':
-            method.dur_use = dict(dist='lognormal', par1=100, par2=1, age_factors=[0, 0, 0, 0, 0, 0])
+            method.dur_use = dict(dist='lognormal', par1=100, par2=1)
         else:
             mlabel = method.csv_name
 

--- a/fpsim/locations/senegal/senegal.py
+++ b/fpsim/locations/senegal/senegal.py
@@ -22,7 +22,6 @@ def scalar_pars():
         # Scale parameter of gumbel distribution. Requires children's recode DHS file, see data_processing/breastfeedin_stats.R
         'abortion_prob': 0.08,  # From https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4712915/
         'twins_prob': 0.015,  # From https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0025239
-        'mcpr_norm_year': 2018,  # Year to normalize MCPR trend to 1
     }
     return scalar_pars
 

--- a/fpsim/methods.py
+++ b/fpsim/methods.py
@@ -161,6 +161,7 @@ class SimpleChoice(RandomChoice):
             prob_use_year=2000,
             prob_use_trend_par=0.1,
             force_choose=False,  # Whether to force non-users to choose a method
+            method_weights=np.ones(self.n_methods),
         )
         updated_pars = sc.mergedicts(default_pars, pars)
         self.pars = sc.mergedicts(self.pars, updated_pars)
@@ -303,7 +304,8 @@ class SimpleChoice(RandomChoice):
                         else:
                             these_probs = mcp[key][mname]  # Cannot stay on method
                             these_probs = [p if p > 0 else p+fpu.sample(**jitter_dist)[0] for p in these_probs]  # No 0s
-                            these_probs = np.array(these_probs)/sum(these_probs)  # Renormalize
+                            these_probs = np.array(these_probs) * self.pars['method_weights']  # Scale by weights
+                            these_probs = these_probs/sum(these_probs)  # Renormalize
                             these_choices = fpu.n_multinomial(these_probs, len(switch_iinds))  # Choose
 
                             # Adjust method indexing to correspond to datafile (removing None: Marita to confirm)

--- a/fpsim/methods.py
+++ b/fpsim/methods.py
@@ -193,7 +193,8 @@ class SimpleChoice(RandomChoice):
                 ppl_this_age = this_age_bools.nonzero()[-1]
                 if len(ppl_this_age) > 0:
                     these_probs = self.init_dist[key]
-                    these_probs = np.array(these_probs)/sum(these_probs)  # Renormalize
+                    these_probs = np.array(these_probs) * self.pars['method_weights']  # Scale by weights
+                    these_probs = these_probs/sum(these_probs)  # Renormalize
                     these_choices = fpu.n_multinomial(these_probs, len(ppl_this_age))  # Choose
                     # Adjust method indexing to correspond to datafile (removing None: Marita to confirm)
                     choice_array[this_age_bools] = np.array(list(self.init_dist.method_idx))[these_choices]
@@ -326,7 +327,8 @@ class SimpleChoice(RandomChoice):
             if len(switch_iinds):
                 these_probs = mcp[key]
                 these_probs = [p if p > 0 else p+fpu.sample(**jitter_dist)[0] for p in these_probs]  # No 0s
-                these_probs = np.array(these_probs)/sum(these_probs)  # Renormalize
+                these_probs = np.array(these_probs) * self.pars['method_weights']  # Scale by weights
+                these_probs = these_probs/sum(these_probs)  # Renormalize
                 these_choices = fpu.n_multinomial(these_probs, len(switch_iinds))  # Choose
                 choice_array[switch_iinds] = np.array(list(mcp.method_idx))[these_choices]
 

--- a/fpsim/parameters.py
+++ b/fpsim/parameters.py
@@ -215,15 +215,8 @@ default_pars = {
     # Fecundity and exposure
     'fecundity_var_low':    0.7,
     'fecundity_var_high':   1.1,
-    'high_parity':          4,
-    'high_parity_nonuse':   0.6,
     'primary_infertility':  0.05,
     'exposure_factor':      1.0,    # Overall exposure correction factor
-
-    # MCPR
-    'mcpr_growth_rate':     0.02,   # Year-on-year change in MCPR after the end of the data
-    'mcpr_max':             0.9,    # Do not allow MCPR to increase beyond this
-    'mcpr_norm_year':       None,   # CONTEXT-SPECIFIC #### - year to normalize MCPR trend to 1
 
     # Other sim parameters
     'mortality_probs':      {},

--- a/fpsim/people.py
+++ b/fpsim/people.py
@@ -23,7 +23,7 @@ class People(fpb.BasePeople):
     """
 
     def __init__(self, pars, n=None, age=None, sex=None,
-                 contraception_module=None, empowerment_module=None, education_module=None, **kwargs):
+                 empowerment_module=None, education_module=None, **kwargs):
 
         # Initialization
         super().__init__(**kwargs)

--- a/fpsim/people.py
+++ b/fpsim/people.py
@@ -221,6 +221,7 @@ class People(fpb.BasePeople):
 
                 # Get previous users and see whether they will switch methods or stop using
                 if len(choosers):
+
                     choosers.on_contra = cm.get_contra_users(choosers, year=year)
                     choosers.ever_used_contra = choosers.ever_used_contra | choosers.on_contra
 
@@ -957,7 +958,7 @@ class People(fpb.BasePeople):
 
         # Add check for ti contra
         if (self.ti_contra < 0).any():
-            errormsg = 'Invalid values for ti_contra'
+            errormsg = f'Invalid values for ti_contra at timestep {self.ti}'
             raise ValueError(errormsg)
 
         return self.step_results

--- a/fpsim/people.py
+++ b/fpsim/people.py
@@ -98,6 +98,10 @@ class People(fpb.BasePeople):
 
         return
 
+    @property
+    def dt(self):
+        return self.pars['timestep'] / fpd.mpy
+
     def get_urban(self, n):
         """ Get initial distribution of urban """
         urban_prop = self.pars['urban_prop']
@@ -138,13 +142,28 @@ class People(fpb.BasePeople):
         return
 
     def init_methods(self, ti=None, year=None, contraception_module=None):
+
+        # Initialize sexual debut
+        fecund = self.filter((self.sex == 0) * (self.age < self.pars['age_limit_fecundity']))
+        fecund.check_sexually_active()
+
+        # Determine when girls/women will first choose a method
+        time_to_debut = (fecund.fated_debut-fecund.age)/self.dt
+        fecund.ti_contra = np.maximum(time_to_debut, 0)
+        time_to_set_contra = fecund.ti_contra == 0
+        if not np.array_equal(((fecund.age - fecund.fated_debut) > -self.dt), time_to_set_contra):
+            errormsg = 'Should be choosing contraception for everyone past fated debut age.'
+            raise ValueError(errormsg)
+        contra_choosers = fecund.filter(time_to_set_contra)
+
         if contraception_module is not None:
             self.contraception_module = contraception_module
-            self.on_contra = contraception_module.get_contra_users(self, year=year)
-            oc = self.filter(self.on_contra)
+            contra_choosers.on_contra = contraception_module.get_contra_users(contra_choosers, year=year)
+            oc = contra_choosers.filter(contra_choosers.on_contra)
             oc.method = contraception_module.init_method_dist(oc)
             oc.ever_used_contra = 1
-            self.ti_contra = ti + contraception_module.set_dur_method(self)
+            method_dur = contraception_module.set_dur_method(contra_choosers)
+            contra_choosers.ti_contra = ti + method_dur
 
     def update_fertility_intent_by_age(self):
         """
@@ -210,11 +229,12 @@ class People(fpb.BasePeople):
                     stopping_contra = choosers.filter(~choosers.on_contra)
                     pp0.step_results['contra_access'] += len(switching_contra)
 
-                    # For those who keep using, determine their next method and update time
-                    switching_contra.method = cm.choose_method(switching_contra)
+                    # For those who keep using, choose their next method
+                    if len(switching_contra):
+                        switching_contra.method = cm.choose_method(switching_contra)
 
-                    # For those who stop using, determine when next to update
-                    if len(stopping_contra) > 0:
+                    # For those who stop using, set method to zero
+                    if len(stopping_contra):
                         stopping_contra.method = 0
 
                 # Validate
@@ -301,6 +321,7 @@ class People(fpb.BasePeople):
         """
         Decide if agent is sexually active based either on month postpartum or age if
         not postpartum.  Postpartum and general age-based data from DHS.
+        Agents can revert to active or not active each timestep
         """
         # Set postpartum probabilities
         match_low = self.postpartum_dur >= 0
@@ -311,29 +332,27 @@ class People(fpb.BasePeople):
         non_pp = self.filter(non_pp_match)
 
         # Adjust for postpartum women's birth spacing preferences
-        pref = self.pars['spacing_pref']  # Shorten since used a lot
-        spacing_bins = pp.postpartum_dur / pref['interval']  # Main calculation -- divide the duration by the interval
-        spacing_bins = np.array(np.minimum(spacing_bins, pref['n_bins']),
-                                dtype=int)  # Convert to an integer and bound by longest bin
-        probs_pp = self.pars['sexual_activity_pp']['percent_active'][pp.postpartum_dur]
-        probs_pp *= pref['preference'][
-            spacing_bins]  # Actually adjust the probability -- check the overall probability with print(pref['preference'][spacing_bins].mean())
+        if len(pp):
+            pref = self.pars['spacing_pref']  # Shorten since used a lot
+            spacing_bins = pp.postpartum_dur / pref['interval']  # Main calculation: divide the duration by the interval
+            spacing_bins = np.array(np.minimum(spacing_bins, pref['n_bins']), dtype=int)  # Bound by longest bin
+            probs_pp = self.pars['sexual_activity_pp']['percent_active'][pp.postpartum_dur]
+            # Adjust the probability: check the overall probability with print(pref['preference'][spacing_bins].mean())
+            probs_pp *= pref['preference'][spacing_bins]
+            pp.sexually_active = fpu.binomial_arr(probs_pp)
 
         # Set non-postpartum probabilities
-        probs_non_pp = self.pars['sexual_activity'][non_pp.int_age]
+        if len(non_pp):
+            probs_non_pp = self.pars['sexual_activity'][non_pp.int_age]
+            non_pp.sexually_active = fpu.binomial_arr(probs_non_pp)
 
-        # Evaluate likelihood in this time step of being sexually active
-        # Can revert to active or not active each timestep
-        pp.sexually_active = fpu.binomial_arr(probs_pp)
-        non_pp.sexually_active = fpu.binomial_arr(probs_non_pp)
-
-        # Set debut to True if sexually active for the first time
-        # Record agent age at sexual debut in their memory
-        never_sex = non_pp.sexual_debut == 0
-        now_active = non_pp.sexually_active == 1
-        first_debut = non_pp.filter(now_active * never_sex)
-        first_debut.sexual_debut = True
-        first_debut.sexual_debut_age = first_debut.age
+            # Set debut to True if sexually active for the first time
+            # Record agent age at sexual debut in their memory
+            never_sex = non_pp.sexual_debut == 0
+            now_active = non_pp.sexually_active == 1
+            first_debut = non_pp.filter(now_active * never_sex)
+            first_debut.sexual_debut = True
+            first_debut.sexual_debut_age = first_debut.age
 
         active_sex = self.sexually_active == 1
         debuted = self.sexual_debut == 1

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -276,8 +276,10 @@ class Sim(fpb.BaseSim):
         """Expand population size"""
         # Births
         new_people = fpppl.People(
-                    pars=self.pars, n=n_new_people, age=0, method_selector=self.contraception_module,
-                    education_module=self.education_module, empowerment_module=self.empowerment_module)
+                    pars=self.pars, n=n_new_people, age=0,
+                    education_module=self.education_module, empowerment_module=self.empowerment_module
+                    )
+        new_people.init_methods(ti=self.ti, year=self.y, contraception_module=self.contraception_module)
         self.people += new_people
 
     def step(self):

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -144,7 +144,7 @@ class Sim(fpb.BaseSim):
             fpu.set_seed(self['seed'])
             self.init_results()
             self.init_people()  # This step also initializes the empowerment and education modules if provided
-            self.init_methods()
+            self.init_methods()  # Initialize methods
         return self
 
     def init_results(self):

--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -1,17 +1,17 @@
 {
   "model": {
-    "pop_size_mean": 1118.8360655737704,
-    "pop_growth_rate_mean": 0.4051862395955918,
+    "pop_size_mean": 1137.6065573770493,
+    "pop_growth_rate_mean": 0.46240287867674945,
     "mcpr_mean": 0.0,
     "maternal_mortality_ratio": 0.0,
-    "infant_mortality_rate": 111.1111111111111,
-    "crude_death_rate": 9.426551453260016,
-    "crude_birth_rate": 14.139827179890023,
-    "total_fertility_rate_mean": 2.1350322968858664,
-    "asfr_mean": 56.15480809840567,
+    "infant_mortality_rate": 0.0,
+    "crude_death_rate": 14.437689969604863,
+    "crude_birth_rate": 15.197568389057752,
+    "total_fertility_rate_mean": 2.3047465295851866,
+    "asfr_mean": 55.900826308042284,
     "ageparity_mean": 2.0408163265306127,
-    "spacing_stats_mean": 5.083333333333456,
-    "age_first_stats_mean": 30.480684457873423,
+    "spacing_stats_mean": 4.611111111111144,
+    "age_first_stats_mean": 29.595036408780107,
     "method_counts_mean": 0.09999999999999999
   },
   "data": {

--- a/tests/benchmark.json
+++ b/tests/benchmark.json
@@ -1,9 +1,9 @@
 {
   "time": {
-    "initialize": 0.002,
-    "run": 2.595,
+    "initialize": 0.004,
+    "run": 2.92,
     "postprocess": 0.044,
-    "total": 2.641
+    "total": 2.967
   },
   "parameters": {
     "n": 1000,
@@ -11,5 +11,5 @@
     "end_year": 2020,
     "timestep": 1
   },
-  "cpu_performance": 0.5158744815794817
+  "cpu_performance": 0.5153517495522688
 }

--- a/tests/benchmark.json
+++ b/tests/benchmark.json
@@ -1,9 +1,9 @@
 {
   "time": {
     "initialize": 0.002,
-    "run": 2.326,
-    "postprocess": 0.046,
-    "total": 2.374
+    "run": 2.595,
+    "postprocess": 0.044,
+    "total": 2.641
   },
   "parameters": {
     "n": 1000,
@@ -11,5 +11,5 @@
     "end_year": 2020,
     "timestep": 1
   },
-  "cpu_performance": 0.5212408839838426
+  "cpu_performance": 0.5158744815794817
 }

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -47,35 +47,15 @@ def test_change_par():
     s0 = make_sim(label='Baseline')
     s1 = make_sim(interventions=cp1, label='High exposure')
 
-    # Define MCPR growth test
-    sim_start = 2015
-    mcpr_y1   = 2020 # When the MCPR projection starts
-    mcpr_y2   = 2030 # Max MCPR
-    mcpr_y3   = 2038 # MCPR should've declined
-    sim_end   = 2040 # Reset at this point
-    cp2 = fp.change_par('mcpr_growth_rate', vals={mcpr_y1:0.10, mcpr_y2:-0.10, mcpr_y3:'reset'}, verbose=verbose) # Set to large positive then negative growth
-    s2 = make_sim(interventions=cp2, start_year=sim_start, end_year=sim_end, label='Changing MCPR')
-
     # Run
-    m = fp.parallel(s0, s1, s2, serial=serial, compute_stats=False)
-    s0, s1, s2 = m.sims[:] # Replace with run versions
+    m = fp.parallel(s0, s1, serial=serial, compute_stats=False)
+    s0, s1, = m.sims[:] # Replace with run versions
 
     # Test exposure factor change
     base_births = s0.results['births'].sum()
     cp_births   = s1.results['births'].sum()
     assert s1['exposure_factor'] == ec, f'change_pars() did not change exposure factor to {ec}'
     assert cp_births < base_births, f'Reducing exposure factor should reduce births, but {cp_births} is not less than the baseline of {base_births}'
-
-    ## RS NOTE: Commenting out this test as it won't work with the new methodtime implementation
-    # # Test MCPR growth
-    # r = s2.results
-    # ind_y1 = sc.findnearest(r.t, mcpr_y1)
-    # ind_y2 = sc.findnearest(r.t, mcpr_y2)
-    # ind_y3 = sc.findnearest(r.t, mcpr_y3)
-    # assert ind_y1 != ind_y2 != ind_y3, f'Sim indices for years years {mcpr_y1}, {mcpr_y2}, {sim_end} should be different'
-    # assert r.mcpr[ind_y1] < r.mcpr[ind_y2], f'MCPR did not grow from {mcpr_y1} to {mcpr_y2}'
-    # assert r.mcpr[ind_y3] < r.mcpr[ind_y2], f'MCPR did not shrink from {mcpr_y2} to {sim_end}'
-    # assert s2['mcpr_growth_rate'] == s0['mcpr_growth_rate'], 'MCPR growth rate did not reset correctly'
 
     # Check user input validation
     with pytest.raises(ValueError): # Check that length of years and values match
@@ -97,7 +77,7 @@ def test_plot():
     sc.heading('Testing intervention plotting...')
 
     cp = fp.change_par(par='exposure_factor', years=2002, vals=2.0) # Reduce exposure factor
-    um1 = fp.update_methods(year=2005, eff={'Injectables':1.0})
+    um1 = fp.update_methods(year=2005, eff={'Injectables': 1.0})
     um2 = fp.update_methods(year=2008, p_use=0.5)
     um3 = fp.update_methods(year=2010, method_mix=[0.9, 0.1, 0, 0, 0, 0, 0, 0, 0])
     sim = make_sim(interventions=[cp, um1, um2, um3]).run()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -23,7 +23,7 @@ def test_null(do_plot=do_plot):
     pars = fp.pars('test')  # For default pars
 
     # Set things to zero
-    for key in ['exposure_factor', 'high_parity_nonuse']:
+    for key in ['exposure_factor']:
         pars[key] = 0
 
     for key in ['f', 'm']:

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -22,8 +22,14 @@ def test_simple_choice(location='kenya'):
     sc.heading('Method choice is based on age & previous method')
 
     # Make & run sim
+    import numpy as np
     pars = fp.pars(location=location, **par_kwargs)
-    method_choice = fp.SimpleChoice(pars=dict(prob_use_trend_par=0.1, force_choose=True), location=location, methods=sc.dcp(fp.Methods))
+    cm_pars = dict(
+        prob_use_trend_par=0.1,
+        force_choose=False,
+        method_weights=np.array([0.1, 2, 0.5, 0.5, 2, 1, 1.5, 0.5, 5])
+    )
+    method_choice = fp.SimpleChoice(pars=cm_pars, location=location, methods=sc.dcp(fp.Methods))
     sim = fp.Sim(pars, contraception_module=method_choice, analyzers=fp.cpr_by_age())
     sim.run()
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -92,6 +92,6 @@ def test_empowered_choice():
 
 if __name__ == '__main__':
 
-    # s0 = test_simple()
+    s0 = test_simple()
     s1 = test_simple_choice()
-    # s2 = test_empowered_choice()
+    s2 = test_empowered_choice()


### PR DESCRIPTION
Fixes https://github.com/fpsim/fpsim/issues/364

Results from running test_sim.py with default method_weights:
![Screen Shot 2024-07-17 at 1 26 01 pm](https://github.com/user-attachments/assets/f7e0886b-275f-4158-820b-9235a2dba933)

Results from running test_sim.py with custom method_weights (`np.array([0.1, 2, 0.5, 0.5, 2, 1, 1.5, 0.5, 5])`)
![Screen Shot 2024-07-17 at 1 25 22 pm](https://github.com/user-attachments/assets/13dedb53-5b1c-4100-b780-35fb087fd923)

@emilydriano these method_weights are used to scale the probabilities of choosing each method, but the probabilities are then renormalized so it doesn't translate directly to being x-fold more likely. But you should still be able to tweak these in calibration, using the general rule that if there aren't enough users of a given method, you increase the weight assigned to that method.
