### PR TITLE
Issue 347 Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ All notable changes to the codebase are documented in this file. Changes that ma
    :local:
    :depth: 1
 
+Version 1.0.2 (2024-07-25)
+---------------------------
+- Fixes issue 347, correcting variable in defaults storing age-specific results
+- *GitHub info*: PR `https://github.com/fpsim/fpsim/pull/388>`_
+
 Version 1.0.1 (2024-06-17)
 ---------------------------
 - Adds empowerment metrics (paid work and education attainment) to calibration targets

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -563,7 +563,12 @@ class Sim(fpb.BaseSim):
         # Convert all results to Numpy arrays
         for key, arr in self.results.items():
             if isinstance(arr, list):
-                self.results[key] = np.array(arr, dtype=object)  # Convert any lists to arrays
+                # These keys have list of lists with different lengths
+                if key in ['imr_numerator', 'imr_denominator', 'mmr_numerator', 'mmr_denominator', 'imr_age_by_group',
+                            'mmr_age_by_group', 'as_stillbirths', 'stillbirth_ages']:
+                    self.results[key] = np.array(arr, dtype=object)
+                else:
+                    self.results[key] = np.array(arr)  # Convert any lists to arrays
 
         # Calculate cumulative totals
         self.results['cum_maternal_deaths_by_year'] = np.cumsum(self.results['maternal_deaths_over_year'])

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -166,7 +166,7 @@ class Sim(fpb.BaseSim):
             self.results['imr_age_by_group'] = []
             self.results['mmr_age_by_group'] = []
             self.results['stillbirth_ages'] = []
-            for age_specific_channel in fpd.age_specific_results:
+            for age_specific_channel in fpd.by_age_results:
                 for age_group in fpd.age_specific_channel_bins:
                     if 'numerator' in age_specific_channel or 'denominator' in age_specific_channel or 'as_' in age_specific_channel:
                         self.results[age_specific_channel] = []
@@ -563,7 +563,7 @@ class Sim(fpb.BaseSim):
         # Convert all results to Numpy arrays
         for key, arr in self.results.items():
             if isinstance(arr, list):
-                self.results[key] = np.array(arr)  # Convert any lists to arrays
+                self.results[key] = np.array(arr, dtype=object)  # Convert any lists to arrays
 
         # Calculate cumulative totals
         self.results['cum_maternal_deaths_by_year'] = np.cumsum(self.results['maternal_deaths_over_year'])

--- a/fpsim/version.py
+++ b/fpsim/version.py
@@ -1,5 +1,5 @@
 
-__version__ = '1.0.1'
-__versiondate__ = '2024-06-17'
+__version__ = '1.0.2'
+__versiondate__ = '2024-07-25'
 
 __license__ = f'FPsim {__version__} ({__versiondate__}) — © 2019-2024 by IDM'

--- a/tests/benchmark.json
+++ b/tests/benchmark.json
@@ -1,9 +1,9 @@
 {
   "time": {
-    "initialize": 0.003,
-    "run": 3.978,
-    "postprocess": 0.124,
-    "total": 4.105
+    "initialize": 0.0,
+    "run": 3.054,
+    "postprocess": 0.088,
+    "total": 3.143
   },
   "parameters": {
     "n": 1000,
@@ -11,5 +11,5 @@
     "end_year": 2020,
     "timestep": 1
   },
-  "cpu_performance": 0.5264000940382162
+  "cpu_performance": 0.8665430356444568
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -158,6 +158,18 @@ def test_method_usage():
     
     return sim
 
+def test_track_as():
+    '''Test that track_as can be be used to plot age-specific results'''
+    # Set options
+    pars = fp.pars(location='test', track_as=True)
+    sim = fp.Sim(pars=pars)
+    sim.run()
+
+    if do_plot:
+        sim.plot()
+
+    return sim
+
 # Run all tests
 if __name__ == '__main__':
 
@@ -169,3 +181,4 @@ if __name__ == '__main__':
         ppl  = test_plot_people()
         res  = test_samples()
         method = test_method_usage()
+        sim = test_track_as()


### PR DESCRIPTION
### Brief description
Resolves #347 to fix ability to use track_as for plotting age-specific outcomes

### Type(s) of change
- [ X ] Bugfix
- [ ] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [ X ] Yes
  - [ ] N/A
- I've commented my code
  - [ X ] Yes
  - [ ] N/A
- I've incremented the version number
  - [ X ] Yes
  - [ ] N/A
- I've updated the changelog
  - [ X ] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [ X ] Yes
  - [ ] N/A