### PR TITLE
MMBA Analyzer bug fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ All notable changes to the codebase are documented in this file. Changes that ma
    :local:
    :depth: 1
 
+Version 3.0.1 (2025-07-15)
+---------------------------
+- Fixes issue 567 (Removes legacy use_subnational logic)
+- *GitHub info*: PR `392 <https://github.com/fpsim/fpsim/pull/392>`_
 
 Version 3.0.0 (2025-06-26)
 ---------------------------

--- a/fpsim/analyzers.py
+++ b/fpsim/analyzers.py
@@ -115,21 +115,24 @@ class method_mix_by_age(ss.Analyzer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)   # Initialize the Analyzer object
         self.age_bins = [v[1] for v in fpd.method_age_map.values()]
-        self.results = None
+        self.mmba_results = None
         self.n_methods = None
         return
+
+    def step(self):
+        pass
 
     def finalize(self):
         sim = self.sim
         ppl = sim.people
-        n_methods = len(sim.contraception_module.methods)
-        self.results = {k: np.zeros(n_methods) for k in fpd.method_age_map.keys()}
+        n_methods = len(sim.people.contraception_module.methods)
+        self.mmba_results = {k: np.zeros(n_methods) for k in fpd.method_age_map.keys()}
         for key, (age_low, age_high) in fpd.method_age_map.items():
             match_low_high = (ppl.age >= age_low) & (ppl.age < age_high)
-            denom_conds = match_low_high * (ppl.sex == 0) * ppl.alive
+            denom_conds = match_low_high * (ppl.female == True) * ppl.alive
             for mn in range(n_methods):
                 num_conds = denom_conds * (ppl.method == mn)
-                self.results[key][mn] = sc.safedivide(np.count_nonzero(num_conds), np.count_nonzero(denom_conds))
+                self.mmba_results[key][mn] = sc.safedivide(np.count_nonzero(num_conds), np.count_nonzero(denom_conds))
         return
 
 class education_recorder(ss.Analyzer):

--- a/fpsim/version.py
+++ b/fpsim/version.py
@@ -1,3 +1,3 @@
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 __versiondate__ = '2025-06-26'
 __license__ = f'FPsim {__version__} ({__versiondate__}) — © 2019-2025 by IDM'

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -98,6 +98,20 @@ def test_longitudinal():
 
     return
 
+def test_method_mix_by_age():
+    sc.heading('Testing method mix by age analyzer...')
+
+    # Create a sim with the method mix by age analyzer
+    mmba = fp.method_mix_by_age()
+    sim = fp.Sim(analyzers=[mmba])
+    sim.init()
+    sim.run()
+
+    # Check that the analyzer has been populated
+    assert sim.analyzers.method_mix_by_age.mmba_results is not None, 'Method mix by age results should not be empty'
+
+    return
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Brief description
Including the `method_mix_by_age` analyzer in a sim caused sim initialization to fail. This was because the `.result` field was being overridden. After fixing this I identified a few other object paths that weren't correct so I updated those as well.

### Type(s) of change
- [X] Bugfix
- [ ] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [X] Yes
  - [ ] N/A
- I've commented my code
  - [ ] Yes
  - [X] N/A
- I've incremented the version number
  - [X] Yes
  - [ ] N/A
- I've updated the changelog
  - [X] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [X] Yes
  - [ ] N/A