### PR TITLE
Starsim v3 migration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ All notable changes to the codebase are documented in this file. Changes that ma
    :local:
    :depth: 1
 
+Version 3.2.0 (2025-08-04)
+---------------------------
+- Updates to be compatible with / require Starsim v3.0.1; baselines have changed but otherwise functionality is (more or less) unchanged.
+- Fixed a bug with ``fp.Sim(copy_inputs=False`` being ignored.
+- *GitHub info*: PR `575 <https://github.com/fpsim/fpsim/pull/575>`_
+
+
 Version 3.1.0 (2025-07-31)
 ---------------------------
 - Refactors Contraception and Education to Starsim modules (connectors)

--- a/fpsim/calibration.py
+++ b/fpsim/calibration.py
@@ -175,7 +175,10 @@ class Calibration(sc.prettyobj):
 
     def run_workers(self):
         ''' Run multiple workers in parallel '''
-        output = sc.parallelize(self.worker, self.g.n_workers)
+        if self.g.n_workers > 1:
+            output = sc.parallelize(self.worker, self.g.n_workers)
+        else:
+            output = self.worker()
         return output
 
     def remove_db(self):

--- a/fpsim/defaults.py
+++ b/fpsim/defaults.py
@@ -65,22 +65,22 @@ def register_location(name, location_ref):
 # or updated during the course of a simulation.
 person_defaults = [
     # Contraception
-    ss.State('on_contra', default=False),  # whether she's on contraception
+    ss.BoolState('on_contra', default=False),  # whether she's on contraception
     ss.FloatArr('method', default=0),  # Which method to use. 0 used for those on no method
     ss.FloatArr('ti_contra', default=0),  # time point at which to set method
     ss.FloatArr('barrier', default=0),
-    ss.State('ever_used_contra', default=False),  # Ever been on contraception. 0 for never having used
+    ss.BoolState('ever_used_contra', default=False),  # Ever been on contraception. 0 for never having used
 
     # Sexual and reproductive history
     ss.FloatArr('parity', default=0),
-    ss.State('pregnant', default=False),
-    ss.State('fertile', default=False),
-    ss.State('sexually_active', default=False),
-    ss.State('sexual_debut', default=False),
+    ss.BoolState('pregnant', default=False),
+    ss.BoolState('fertile', default=False),
+    ss.BoolState('sexually_active', default=False),
+    ss.BoolState('sexual_debut', default=False),
     ss.FloatArr('sexual_debut_age', default=-1),
     ss.FloatArr('fated_debut', default=-1),
     ss.FloatArr('first_birth_age', default=-1),
-    ss.State('lactating', default=False),
+    ss.BoolState('lactating', default=False),
     ss.FloatArr('gestation', default=0),
     ss.FloatArr('preg_dur', default=0),
     ss.FloatArr('stillbirth', default=0),
@@ -88,12 +88,12 @@ person_defaults = [
     ss.FloatArr('abortion', default=0),
     ss.FloatArr('pregnancies', default=0),
     ss.FloatArr('months_inactive', default=0),
-    ss.State('postpartum', default=False),
+    ss.BoolState('postpartum', default=False),
     ss.FloatArr('mothers', default=-1),
     ss.FloatArr('short_interval', default=0),
     ss.FloatArr('secondary_birth', default=0), # no functions ever set this value. Used in empowerment?
     ss.FloatArr('postpartum_dur', default=0),
-    ss.State('lam', default=False),
+    ss.BoolState('lam', default=False),
     ss.FloatArr('breastfeed_dur', default=0),
     ss.FloatArr('breastfeed_dur_total', default=0),
 
@@ -102,11 +102,11 @@ person_defaults = [
     ss.FloatArr('personal_fecundity', default=0),
 
     # Partnership information -- states will remain at these values if use_partnership is False
-    ss.State('partnered', default=False),
+    ss.BoolState('partnered', default=False),
     ss.FloatArr('partnership_age', default=-1),
 
     # Socioeconomic
-    ss.State('urban', default=True),
+    ss.BoolState('urban', default=True),
     ss.FloatArr('wealthquintile', default=3), # her current wealth quintile, an indicator of the economic status of her household, 1: poorest quintile; 5: wealthiest quintile
 
     # Add these states to the people object. They are not tracked by timestep in the way other states are, so they

--- a/fpsim/education.py
+++ b/fpsim/education.py
@@ -164,8 +164,8 @@ class Education(ss.Connector):
     def _get_uids(self, upper_age=None):
         """ Get uids of females younger than upper_age """
         people = self.sim.people
-        if upper_age is None: upper_age = 1000
-        within_age = people.age < upper_age
+        if upper_age is None: upper_age = ss.years(100)
+        within_age = people.age < upper_age.years
         return (within_age & people.female).uids
 
     def init_objectives(self, upper_age=None):

--- a/fpsim/education.py
+++ b/fpsim/education.py
@@ -64,11 +64,11 @@ class Education(ss.Connector):
         self.define_states(
             ss.FloatArr('objective'),  # Education objectives
             ss.FloatArr('attainment', default=0),  # Education attainment - initialized as 0, reset if data provided
-            ss.State('started', default=False),  # Whether education has been started
-            ss.State('in_school'),  # Currently in school
-            ss.State('completed'),  # Whether education is completed
-            ss.State('dropped'),  # Whether education was dropped
-            ss.State('interrupted', default=False),
+            ss.BoolState('started', default=False),  # Whether education has been started
+            ss.BoolState('in_school'),  # Currently in school
+            ss.BoolState('completed'),  # Whether education is completed
+            ss.BoolState('dropped'),  # Whether education was dropped
+            ss.BoolState('interrupted', default=False),
         )
 
         # Store things that will be processed after sim initialization

--- a/fpsim/experiment.py
+++ b/fpsim/experiment.py
@@ -173,7 +173,7 @@ class Experiment(sc.prettyobj):
 
 
     def model_mcpr(self, sres=None):
-        model = {'years': sres['mcpr'].timevec, 'mcpr': sres['mcpr']}
+        model = {'years': sres['mcpr'].timevec.years, 'mcpr': sres['mcpr']}
         model_frame = pd.DataFrame(model)
 
         # Filter to matching years

--- a/fpsim/interventions.py
+++ b/fpsim/interventions.py
@@ -89,7 +89,7 @@ class change_par(ss.Intervention):
         self.counter = 0
         self.inds = sc.autolist()
         for y in years:
-            self.inds += sc.findnearest(sim.timevec, y)
+            self.inds += sc.findnearest(sim.timevec.years, y)
 
         # Store original value
         self.orig_val = sc.dcp(sim.fp_pars[self.par])
@@ -324,12 +324,12 @@ class update_methods(ss.Intervention):
             if self.pars.method_mix is not None:
                 this_mix = self.pars.method_mix / np.sum(self.pars.method_mix) # Renormalise in case they are not adding up to 1
                 cm.pars['method_mix'] = this_mix
-            
+
             # Change in switching matrix
             if self.pars.method_choice_pars is not None:
                 print(f'Changed contraceptive switching matrix in year {sim.y}')
                 cm.method_choice_pars = self.pars.method_choice_pars
-                
+
         return
 
 

--- a/fpsim/methods.py
+++ b/fpsim/methods.py
@@ -304,7 +304,7 @@ class SimpleChoice(RandomChoice):
         Return an array of probabilities that each woman will use contraception.
         """
         ppl = self.sim.people
-        year = self.t.now()
+        year = self.t.now('year')
 
         # Figure out which coefficients to use
         if event is None : p = self.contra_use_pars[0]

--- a/fpsim/methods.py
+++ b/fpsim/methods.py
@@ -138,6 +138,7 @@ class ContraceptiveChoice(ss.Connector):
          duration on that method. This method is called by the simulation to initialise the
          people object at the beginning of the simulation and new people born during the simulation.
          """
+        super().init_post()
         ppl = self.sim.people
         fecund = ppl.female & (ppl.age < self.sim.fp_pars['age_limit_fecundity'])
         fecund_uids = fecund.uids

--- a/fpsim/methods.py
+++ b/fpsim/methods.py
@@ -421,7 +421,7 @@ class SimpleChoice(RandomChoice):
                     raise ValueError(errormsg)
 
         dt = ppl.sim.t.dt_year * fpd.mpy
-        timesteps_til_update = np.clip(np.round(dur_method/dt), 1, self.pars['max_dur'].v)  # Include a maximum. Durs seem way too high
+        timesteps_til_update = np.clip(np.round(dur_method/dt), 1, self.pars['max_dur'].years)  # Include a maximum. Durs seem way too high
 
         return timesteps_til_update
 
@@ -518,7 +518,7 @@ class StandardChoice(SimpleChoice):
         Return an array of probabilities that each woman will use contraception.
         """
         ppl = self.sim.people
-        year = self.t.now()
+        year = self.t.now('year')
 
         # Figure out which coefficients to use
         if event is None : p = self.contra_use_pars[0]

--- a/fpsim/parameters.py
+++ b/fpsim/parameters.py
@@ -39,12 +39,13 @@ class SimPars(ss.SimPars):
         return
 
     def update(self, pars=None, create=False, **kwargs):
+        kwargs = sc.mergedicts(pars, kwargs)
         # Pull out test
-        if 'test' in pars or 'test' in kwargs:
+        if 'test' in kwargs:
             print('Running in test mode, with smaller population and shorter time period.')
             self.n_agents = 500
             self.start = 2000
-        super().update(pars=pars, create=create, **kwargs)
+        super().update(create=create, **kwargs)
         return
 
 def make_sim_pars(**kwargs):

--- a/fpsim/parameters.py
+++ b/fpsim/parameters.py
@@ -157,14 +157,18 @@ def make_fp_pars(location=None):
     return FPPars(location=location)
 
 
-def mergepars(*args):
+def mergepars(*args, copy_inputs=True): # TODO: sc.mergedicts() may already have most/all of the required functionality
     """
     Merge all parameter dictionaries into a single dictionary.
     This is used to initialize the SimPars class with all relevant parameters.
     It wraps the sc.mergedicts function to ensure all inputs are dicts
     """
     # Convert any Pars objects to plain dicts and merge
-    dicts = [dict(sc.dcp(arg)) for arg in args if arg is not None]
+    if copy_inputs:
+        dicts = [dict(sc.dcp(arg)) for arg in args if arg is not None]
+    else:
+        dicts = [dict(arg) for arg in args if arg is not None]
+
     merged_pars = sc.mergedicts(*dicts)
     return merged_pars
 

--- a/fpsim/people.py
+++ b/fpsim/people.py
@@ -141,14 +141,14 @@ class People(ss.People):
 
         fecund = uids[(self.female[uids] == True) & (self.age[uids] < self.sim.fp_pars['age_limit_fecundity'])]
 
-        time_to_debut = (self.fated_debut[fecund]-self.age[fecund])/self.sim.t.dt
+        time_to_debut = (self.fated_debut[fecund]-self.age[fecund])/self.sim.t.dt_year
 
         # If ti_contra is less than one timestep away, we want to also set it to 0 so floor time_to_debut.
         self.ti_contra[fecund] = np.maximum(np.floor(time_to_debut), 0)
 
         # Validation
         time_to_set_contra = self.ti_contra[fecund] == 0
-        if not np.array_equal(((self.age[fecund] - self.fated_debut[fecund]) > -self.sim.t.dt), time_to_set_contra):
+        if not np.array_equal(((self.age[fecund] - self.fated_debut[fecund]) > -self.sim.t.dt_year), time_to_set_contra):
             errormsg = 'Should be choosing contraception for everyone past fated debut age.'
             raise ValueError(errormsg)
         return

--- a/fpsim/plotting.py
+++ b/fpsim/plotting.py
@@ -146,7 +146,7 @@ def plot_cpr_by_age(sim):
     age_bins = ['<18', '18-20', '20-25', '25-35', '>35']
     for age_key in age_bins:
         ares = sim.analyzers['cpr_by_age'].results[age_key]
-        ax.plot(sim.results['timevec'], ares, label=age_key)
+        ax.plot(sim.results.timevec.years, ares, label=age_key)
     ax.legend(loc='best', frameon=False)
     ax.set_ylim([0, 1])
     ax.set_ylabel('CPR')
@@ -374,7 +374,7 @@ def plot_cpr(sim):
     # Align data for RMSE calculation
     years = data_cpr['year']
     data_values = data_cpr['cpr'].values
-    model_values = np.interp(years, res['timevec'], res['cpr'] * 100)  # Interpolate model CPR to match data years
+    model_values = np.interp(years, res.timevec.years, res.cpr*100)  # Interpolate model CPR to match data years
 
     # Compute mean-normalized RMSE
     rmse_scores['cpr'] = compute_rmse(model_values, data_values)

--- a/fpsim/scenarios.py
+++ b/fpsim/scenarios.py
@@ -405,9 +405,9 @@ class Scenarios(sc.prettyobj):
         def analyze_sim(sim):
             def aggregate_channel(channel, is_sum=True, is_t=False):
                 if is_t:
-                    year = sim.results['timevec']
+                    year = sim.results.timevec.years
                 else:
-                    year = sim.results['tfr_years'].values
+                    year = sim.results.tfr_years.values
                 channel_results = sim.results[channel]
                 inds = sc.findinds((year >= start), year <= end)
 

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -133,8 +133,8 @@ class Sim(ss.Sim):
         self.summary = None
 
         # Add a new parameter to pars that determines the size of the circular buffer = TODO, remove?
-        unit = self.pars.unit if self.pars.unit != "" else 'year'
-        self.fp_pars['tiperyear'] = ss.time_ratio('year', 1, unit, self.pars.dt)
+        # Calculate time intervals per year (replaces ss.time_ratio from Starsim v2)
+        self.fp_pars['tiperyear'] = int(1.0 / self.pars.dt.years)
 
         return
 

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -134,7 +134,7 @@ class Sim(ss.Sim):
 
         # Add a new parameter to pars that determines the size of the circular buffer = TODO, remove?
         # Calculate time intervals per year (replaces ss.time_ratio from Starsim v2)
-        self.fp_pars['tiperyear'] = int(1.0 / self.pars.dt.years)
+        self.fp_pars['tiperyear'] = int(1.0 / self.pars.dt)
 
         return
 

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -224,12 +224,13 @@ class Sim(ss.Sim):
         """
         super().init_results()  # Initialize the base results
 
-        scaling_kw = dict(shape=self.t.npts, timevec=self.t.timevec, dtype=int, scale=True)
+        years = self.t.timevec.years
+        scaling_kw = dict(shape=self.t.npts, timevec=years, dtype=int, scale=True)
 
         for key in fpd.scaling_array_results:
             self.results += ss.Result(key, label=key, **scaling_kw)
 
-        nonscaling_kw = dict(shape=self.t.npts, timevec=self.t.timevec, dtype=float, scale=False)
+        nonscaling_kw = dict(shape=self.t.npts, timevec=years, dtype=float, scale=False)
         for key in fpd.nonscaling_array_results:
             self.results += ss.Result(key, label=key, **nonscaling_kw)
 
@@ -473,8 +474,8 @@ class Sim(ss.Sim):
                     y, low, high = this_res, None, None
 
                 # Figure out x axis
-                years = res['tfr_years']
-                timepoints = res.timevec  # Likewise
+                years = res.tfr_years
+                timepoints = res.timevec.years  # Likewise
                 x = None
                 for x_opt in [years, timepoints]:
                     if len(y) == len(x_opt):

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -336,32 +336,6 @@ class Sim(ss.Sim):
         pp.fillna(0, inplace=True)
         return pp
 
-    def to_df(self, include_range=False):
-        """
-        Export all sim results to a dataframe
-
-        Args:
-            include_range (bool): if True, and if the sim results have best, high, and low, then export all of them; else just best
-        """
-        raw_res = sc.odict(defaultdict=list)
-        for reskey in self.results.keys():
-            res = self.results[reskey]
-            if isinstance(res, dict):
-                for blh, blhres in res.items():  # Best, low, high
-                    if len(blhres) == self.npts:
-                        if not include_range and blh != 'best':
-                            continue
-                        if include_range:
-                            blhkey = f'{reskey}_{blh}'
-                        else:
-                            blhkey = reskey
-                        raw_res[blhkey] += blhres.tolist()
-            elif sc.isarray(res) and len(res) == self.npts:
-                raw_res[reskey] += res.tolist()
-        df = pd.DataFrame(raw_res)
-        self.df = df
-        return df
-
     # Function to scale all y-axes in fig based on input channel
     @staticmethod
     def conform_y_axes(figure, bottom=0, top=100):
@@ -638,6 +612,8 @@ class Sim(ss.Sim):
         raw_res = sc.odict(defaultdict=list)
         for reskey in self.results.keys():
             res = self.results[reskey]
+            if reskey == 'timevec': # Convert to floating-point years
+                res = res.years
             if isinstance(res, dict):
                 for blh, blhres in res.items():  # Best, low, high
                     if len(blhres) == self.t.npts:

--- a/fpsim/sim.py
+++ b/fpsim/sim.py
@@ -278,10 +278,6 @@ class Sim(ss.Sim):
         self.update_mortality()
         self.people.step()
 
-    def finalize(self):
-        self.finalize_results()
-        super().finalize()
-
     def finalize_results(self):
         # Convert all results to Numpy arrays
         for key, arr in self.results.items():
@@ -303,6 +299,7 @@ class Sim(ss.Sim):
         self.results['cum_short_intervals_by_year'] = np.cumsum(self.results['short_intervals_over_year'])
         self.results['cum_secondary_births_by_year'] = np.cumsum(self.results['secondary_births_over_year'])
         self.results['cum_pregnancies_by_year'] = np.cumsum(self.results['pregnancies_over_year'])
+        super().finalize_results() # Scale results
         return
 
     def store_postpartum(self):

--- a/fpsim/version.py
+++ b/fpsim/version.py
@@ -1,3 +1,3 @@
-__version__ = '3.1.0'
-__versiondate__ = '2025-07-31'
+__version__ = '3.2.0'
+__versiondate__ = '2025-08-04'
 __license__ = f'FPsim {__version__} ({__versiondate__}) — © 2019-2025 by IDM'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fpsim"
+dynamic = ["version"]
+description = "FPsim: Family Planning Simulator"
+readme = "README.rst"
+requires-python = ">=3.9"
+license = "MIT"
+license-files = ["LICENSE"]
+keywords = ["family planning", "women's health", "agent-based model", "simulation", "starsim"]
+
+authors = [
+  { name = "Michelle O'Brien", email = "info@fpsim.org" },
+  { name = "Annie Valente" },
+  { name = "Cliff Kerr" },
+  { name = "Robyn Stuart" },
+  { name = "Paula Sanz-Leon" },
+  { name = "Emily Driano" },
+  { name = "Ryan Hull" },
+  { name = "Aasli Nur" },
+  { name = "Navideh Noori" },
+  { name = "Daniel Klein" },
+  { name = "Marita Zimmermann" },
+]
+
+classifiers = [
+  "Intended Audience :: Science/Research",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Development Status :: 5 - Production/Stable",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
+]
+
+dependencies = [
+    "starsim>=3.0.1",
+    "matplotlib>=3.5.0",
+    "seaborn>=0.9",
+    "optuna",
+    "plotnine",
+    "pyarrow",
+    "pyyaml",
+]
+
+[project.urls]
+"Website" = "https://fpsim.org"
+"Source" = "https://github.com/fpsim/fpsim/"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["fpsim*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "fpsim.version.__version__"}

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,6 @@
-import os
-import runpy
-from setuptools import setup, find_packages
+"""
+Legacy support; see pyproject.toml for current information
+"""
+import setuptools
 
-# Get version
-cwd = os.path.abspath(os.path.dirname(__file__))
-versionpath = os.path.join(cwd, 'fpsim', 'version.py')
-version = runpy.run_path(versionpath)['__version__']
-
-# Get the documentation
-with open(os.path.join(cwd, 'README.rst'), "r") as f:
-    long_description = f.read()
-
-CLASSIFIERS = [
-    "Environment :: Console",
-    "Intended Audience :: Science/Research",
-    "License :: Other/Proprietary License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.9",
-]
-
-setup(
-    name="fpsim",
-    version=version,
-    author="Michelle O'Brien, Annie Valente, Cliff Kerr, Sam Buxton, Daniel Klein, Marita Zimmermann, Emily Driano",
-    author_email="info@fpsim.org",
-    description="FPsim: Family Planning Simulator",
-    long_description=long_description,
-    long_description_content_type="text/x-rst",
-    url='http://fpsim.org',
-    keywords=["family planning", "women's health", "agent-based model", "simulation"],
-    platforms=["OS Independent"],
-    classifiers=CLASSIFIERS,
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=[
-        'numpy',
-        'numba',
-        'scipy',
-        'starsim==2.3.1',
-        'pandas>=1.3', 
-        'sciris>=2.1.0',
-        'matplotlib>=3.5.0',
-        'seaborn>=0.9',
-        'optuna',
-        'plotnine',
-        'pyarrow',
-        'pyyaml',
-    ],
-)
+setuptools.setup()

--- a/tests/baseline.json
+++ b/tests/baseline.json
@@ -1,18 +1,18 @@
 {
   "model": {
-    "pop_size_mean": 9778.7,
-    "pop_growth_rate_mean": -0.18949859293489593,
-    "mcpr_mean": 34.82789804503507,
-    "maternal_mortality_ratio": 0.0,
-    "infant_mortality_rate": 18.867924528301884,
-    "crude_death_rate": 14.502605937004306,
-    "crude_birth_rate": 6.004985270790845,
-    "total_fertility_rate_mean": 1.5029312618920503,
-    "asfr_mean": 31.897373881145526,
+    "pop_size_mean": 9758.883333333333,
+    "pop_growth_rate_mean": -0.20909298313687677,
+    "mcpr_mean": 35.34448739185002,
+    "maternal_mortality_ratio": 497.51243781094524,
+    "infant_mortality_rate": 0.0,
+    "crude_death_rate": 13.957213133508752,
+    "crude_birth_rate": 7.66502688479579,
+    "total_fertility_rate_mean": 1.5078406339910548,
+    "asfr_mean": 37.341365992317336,
     "ageparity_mean": 2.040816326530612,
-    "spacing_stats_mean": 3.8611265818277993,
-    "age_first_stats_mean": 22.624740600585938,
-    "method_counts_mean": 0.09999999999999999
+    "spacing_stats_mean": 3.916696548461914,
+    "age_first_stats_mean": 22.69447072347005,
+    "method_counts_mean": 0.10000000000000002
   },
   "data": {
     "pop_size_mean": 26261.302435139336,

--- a/tests/benchmark.json
+++ b/tests/benchmark.json
@@ -1,9 +1,9 @@
 {
   "time": {
     "initialize": 0.003,
-    "run": 13.929,
-    "postprocess": 0.054,
-    "total": 13.986
+    "run": 11.85,
+    "postprocess": 0.051,
+    "total": 11.903
   },
   "parameters": {
     "n": 10000,
@@ -11,5 +11,5 @@
     "end_year": 2020,
     "timestep": 0.08333333333333333
   },
-  "cpu_performance": 0.3245761463236041
+  "cpu_performance": 1.3757915262585305
 }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,8 +5,6 @@ Test different components of the simulation behave as expected
 # Imports
 import sciris as sc
 import fpsim as fp
-from fpsim import utils as fpu
-from fpsim import people as fpppl
 from fpsim import defaults as fpd
 from fpsim import methods as fpm
 from fpsim import interventions as fpi

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -3,12 +3,11 @@ Run tests on the interventions.
 """
 
 import sciris as sc
-import pylab as pl
 import fpsim as fp
 import numpy as np
 
-parallel   = 1 # Whether to run in serial (for debugging)
-do_plot  = 1 # Whether to do plotting in interactive mode
+parallel = False # Whether to run in serial (for debugging)
+do_plot = 1 # Whether to do plotting in interactive mode
 # sc.options(backend='agg') # Turn off interactive plots
 
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,12 +1,9 @@
 """
 Run tests on individual parameters.
 """
-
-import os
 import numpy as np
 import sciris as sc
 import fpsim as fp
-import pytest
 import starsim as ss
 import types
 import fpsim.defaults as fpd
@@ -49,8 +46,6 @@ def test_null(do_plot=do_plot):
 def test_scale():
     sc.heading('Test scale factor')
 
-    # Test settings
-    orig_pop = 100
     scale = 2
 
     # Make and run sims
@@ -64,7 +59,7 @@ def test_scale():
     orig = s1.results.total_births.sum()
     expected = scale*orig
     actual = s2.results.total_births.sum()
-    assert expected == actual, 'Total births should scale exactly with scale factor'
+    assert expected == actual, f'Total births should scale exactly with scale factor, but {expected} != {actual}'
     assert np.array_equal(s1.results.mcpr, s2.results.mcpr), 'Scale factor should not change MCPR'
     ok(f'{actual} births = {scale}*{orig} as expected')
 


### PR DESCRIPTION
# Overview

AI-assisted migration of FPsim from Starsim v2 to Starsim v3, with goal of all tests passing. See also https://github.com/starsimhub/stisim/pull/152 for comparison.

NB: docs are *not* being migrated in this PR.

# 1. AI workflow

Using Claude Code. Timings include both AI and human time.

## 1.1. Planning (10 min)
**Prompt**
Currently this module (fpsim) is built on Starsim v2.3.2. We need to migrate it to Starsim v3.0.0. Specifically, I would like you to migrate the code in @fpsim/ and in @tests/ .

First, read this document and make a migration plan, but do not make any changes yet:
https://github.com/starsimhub/starsim/blob/main/docs/migration_v2v3/README.md 

**Response**
```
● Update Todos
  ⎿  ☐ Read Starsim v2 to v3 migration guide             
     ☐ Analyze current FPsim codebase for v2 dependencies
     ☐ Create detailed migration plan
     ☐ Migrate core modules in fpsim/
     ☐ Migrate test files in tests/
     ☐ Update setup.py dependency from v2.3.1 to v3.0.0
```

It claims there isn't much to do:
>   The migration appears straightforward since FPsim doesn't use many of the heavily changed Starsim v2 features
  like ss.beta(), ss.rate(), or unit parameters. The main work is systematic replacement of State objects and
  the time ratio function.

## 1.2 State migration (3 min)
**Prompt**
OK, please proceed with the migration. Start with the state migrations and then check with me when you're done.

**Response**
Looked good, committed.

## 1.3 Time function migration (10 min)
**Prompt**
Yes, proceed with the time function migration. 

**Response**
Was looking in the wrong folder.

### 1.3.1 Attempt 2 (3 min)
**Prompt**
You were looking in the wrong folder. Only look in @fpsim/ and @tests/.

**Response**
Updated it, but incorrectly.

### 1.3.2 Attempt 3 (3 min)
**Prompt**
Instead of int(1.0 / self.pars.dt), it should be int(1.0 / self.pars.dt.years)

**Response**
Looked correct, committed.

## 1.4 Subfolder migration (5 min)
**Prompt**
No, first please now make any necessary migrations to @fpsim/locations/ and its subfolders.

**Response**
No Starsim usage found -- ok

## 1.5 Tests migration
**Prompt**
Yes please, proceed with migrating the tests

**Response**
Nothing found

# 2. Review

Almost no changes were made! Let's see if it works ...

## 2.1 Simple test run

No:
```py
  File "/home/cliffk/idm/fpsim/fpsim/parameters.py", line 43, in update
    if 'test' in pars or 'test' in kwargs:
       ^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

### 2.1.1 Attempt 1 (10 min)

Fixed dict passing, from
```py
    def update(self, pars=None, create=False, **kwargs):
        # Pull out test
        if 'test' in pars or 'test' in kwargs:
```
to
```py
    def update(self, pars=None, create=False, **kwargs):
        kwargs = sc.mergedicts(pars, kwargs)
        # Pull out test
        if 'test' in kwargs:
```

### 2.1.2 Attempt 2 (3 min)
Error:
```py
--> 551 rhs += (year - self.pars['prob_use_year'])*self.pars['prob_use_trend_par']
TypeError: Attempted to subtract "2000" (<class 'int'>) from a date, which is not supported. Only durations can be subtracted from dates e.g., "ss.years(2000)" or "ss.days(2000)"
```

Fix: replaced
```py
year = self.t.now()
```
with
```py
year = self.t.now('year')
```

### 2.1.3 Attempt 3 (3 min)
Error:
```py
--> 424 timesteps_til_update = np.clip(np.round(dur_method/dt), 1, self.pars['max_dur'].v)  # Include a maximum. Durs seem way too high
    426 return timesteps_til_update

AttributeError: 'years' object has no attribute 'v'
```
Fix: replaced
```py
timesteps_til_update = np.clip(np.round(dur_method/dt), 1, self.pars['max_dur'].v)
```
with
```py
timesteps_til_update = np.clip(np.round(dur_method/dt), 1, self.pars['max_dur'].years)
```

### 2.1.4 Attempt 4 (5 min)
Error:
```py
    151 if not np.array_equal(((self.age[fecund] - self.fated_debut[fecund]) > -self.sim.t.dt), time_to_set_contra):
    152     errormsg = 'Should be choosing contraception for everyone past fated debut age.'
--> 153     raise ValueError(errormsg)
    154 return

ValueError: Should be choosing contraception for everyone past fated debut age.
```

Fix: replaced
```py
time_to_debut = (self.fated_debut[fecund]-self.age[fecund])/self.sim.t.dt
```
with
```py
time_to_debut = (self.fated_debut[fecund]-self.age[fecund])/self.sim.t.dt_year
```

### 2.1.5 Attempt 5 (3 min)
Error:
```py
--> 168 within_age = people.age < upper_age
    169 return (within_age & people.female).uids

TypeError: Can only handle NumPy arrays and Arr objects, not <class 'starsim.time.years'>
```

Fix: replace
```py
if upper_age is None: upper_age = 1000 # 1000?!
within_age = people.age < upper_age
```
with
```py
if upper_age is None: upper_age = ss.years(100)
within_age = people.age < upper_age.years
```

Now runs!

## 2.2 Result comparison
`simple.py` running on `main`:
<img width="2731" height="2000" alt="image" src="https://github.com/user-attachments/assets/bae16f3c-5aa9-4b1c-abe0-bde6fd89c37f" />

`simple.py` running on `starsim-v3`:
<img width="1381" height="1003" alt="image" src="https://github.com/user-attachments/assets/d0ad0221-2c14-4a26-b307-14fb1817a5f4" />

Looks the same except for stochastic differences.

## 2.3 Full test suite

12 failed, 26 passed, almost all failures seem related to needing to convert to years:
```py
 1. AssertionError:: Expected age difference to be equal to 1 year minus the timestep size —————————————————————————————— (FAILED test_analyzers.py::test_longitudinal)
 2. AssertionError:: Last years do not match ———————————————————————————————————————————————————————————————————————————— (FAILED test_other.py::test_to_df)
 3. AssertionError:: Total births should scale exactly with scale factor ———————————————————————————————————————————————— (FAILED test_parameters.py::test_scale)
 4. TypeError:: Attempted to subtract "2000" (<class 'int'>) from a date, which is not supported. Only durations can ...  (FAILED test_integration.py::test_method_selection_dependencies)
 5. TypeError:: Attempted to subtract "2000" (<class 'int'>) from a date, which is not supported. Only durations can ...  (FAILED test_sim.py::test_sim_creation)
 6. TypeError:: Attempted to subtract "2002" (<class 'int'>) from a date, which is not supported. Only durations can ...  (FAILED test_interventions.py::test_plot)
 7. TypeError:: Cannot cast array data from dtype('O') to dtype('float64') according to the rule 'safe' ————————————————— (FAILED test_other.py::test_plotting_class)
 8. TypeError:: Cannot cast array data from dtype('O') to dtype('float64') according to the rule 'safe' ————————————————— (FAILED test_other.py::test_plotting_regional)
 9. TypeError:: Task 0 failed: set die=False to keep going instead; see above for error details ————————————————————————— (FAILED test_interventions.py::test_change_people_state)
10. TypeError:: Task 1 failed: set die=False to keep going instead; see above for error details ————————————————————————— (FAILED test_sim.py::test_simple_choice)
11. TypeError:: Task 2 failed: set die=False to keep going instead; see above for error details ————————————————————————— (FAILED test_interventions.py::test_change_par)
12. ValueError:: Could not determine relationship between sim1=34.82789804503507 and sim2=nan ——————————————————————————— (FAILED test_baselines.py::test_baseline)
```

### 2.3.1 Attempt 1 (15 min)
Replaced `timevec` with `timevec.years`: 12 → 10 failed

### 2.3.2 Attempt 2 (10 min)
Replaced `self.t.now()` with `self.t.now('year')`: 10 → 6 failed

### 2.3.3 Attempt 3 (30 min)
Fixed issue with result finalization logic in Starsim: 6 → 5 failed

### 2.3.4 Attempt 4 (several hours)
Decided to redo how Starsim handles time units, and found a number of bugs in FPsim along the way.


# 3. Conclusion

Migration wasn't too bad -- most of the time was spent either updating Starsim or dealing with existing FPsim bugs (which hadn't arisen prior to the migration).

