### PR TITLE
fixed x axis of UN data for MCPR and reenabled the ASFR plot.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ All notable changes to the codebase are documented in this file. Changes that ma
    :local:
    :depth: 1
 
+Version 3.3.1 (2025-09-05)
+---------------------------
+Minor bugfix in plotting.plot_calib(). Fixes x axis units for MCPR plot and reenables ASFR plot.
+
 Version 3.2.0 (2025-08-15)
 ---------------------------
 

--- a/fpsim/plotting.py
+++ b/fpsim/plotting.py
@@ -434,7 +434,7 @@ def plot_cpr(sim, start_year=2005, end_year=None, ax=None, legend_kwargs={}):
 
     # Plot
     ax.plot(plot_data['year'], plot_data['cpr'], label='UN Data Portal', color='black')
-    ax.plot(res['timevec'][si:], res.contraception.mcpr[si:] * 100, label='FPsim', color='cornflowerblue')
+    ax.plot(res['timevec'][si:].years, res.contraception.mcpr[si:] * 100, label='FPsim', color='cornflowerblue')
     ax.set_xlabel('Year')
     ax.set_ylabel('Percent')
     if Config.show_rmse is True:
@@ -836,7 +836,7 @@ def plot_calib(sim, single_fig=False, fig_kwargs=None, legend_kwargs=None):
     plot_method_mix(sim, ax=ax_arg(3), legend_kwargs=legend_kwargs)
     plot_afb(sim, ax=ax_arg(4), legend_kwargs=legend_kwargs)
     plot_birth_spacing(sim, ax=ax_arg(5), legend_kwargs=legend_kwargs)
-    # plot_asfr(sim, ax=ax_arg(5))
+    plot_asfr(sim, ax=ax_arg(5))
 
     if single_fig:
         fig.tight_layout()

--- a/fpsim/version.py
+++ b/fpsim/version.py
@@ -1,3 +1,3 @@
-__version__ = '3.3.0'
+__version__ = '3.3.1'
 __versiondate__ = '2025-08-26'
 __license__ = f'FPsim {__version__} ({__versiondate__}) — © 2019-2025 by IDM'


### PR DESCRIPTION
### Brief description
MCPR plot in plot_calib() was not displaying the UN data correctly, and ASFR plot had been disabled. Fixes both.

### Type(s) of change
- [X] Bugfix
- [ ] Refactor
- [ ] New feature
- [ ] Other

### Checklist
- My code follows the [style guide](https://github.com/amath-idm/styleguide)
  - [ ] Yes
  - [X] N/A
- I've commented my code
  - [X] Yes
  - [ ] N/A
- I've incremented the version number
  - [X] Yes
  - [ ] N/A
- I've updated the changelog
  - [X] Yes
  - [ ] N/A
- I've added tests and checked code coverage
  - [ ] Yes
  - [X] N/A