### PR TITLE
Fix pandas v3.0.0 compatibility issues

### DIFF
--- a/fpsim/data_processing/DHS_PMA_scripts/dhs_parse_mcprbyparity.py
+++ b/fpsim/data_processing/DHS_PMA_scripts/dhs_parse_mcprbyparity.py
@@ -56,7 +56,7 @@ def process_cpr(data, method_value, method_code = 'v313'):
     """
     data = data.reset_index()
     method = data[data[method_code]==method_value]
-    method.reset_index(drop=True, inplace=True)
+    method = method.reset_index(drop=True)
 
     return method
 

--- a/fpsim/data_processing/UN_WB_data_scraping/UN_data_scraping.py
+++ b/fpsim/data_processing/UN_WB_data_scraping/UN_data_scraping.py
@@ -188,8 +188,8 @@ if get_cpr:
     df_mcpr = df.loc[(df['category'] == 'All women') & (df['variantLabel'] == 'Median') & (df['indicatorId'] == mcpr_ind)]
     df_cpr = df_cpr.filter(['timeLabel', 'value'])
     df_mcpr = df_mcpr.filter(['timeLabel', 'value'])
-    df_cpr.rename(columns={'timeLabel': 'year', 'value': 'cpr'}, inplace=True)
-    df_mcpr.rename(columns={'timeLabel': 'year', 'value': 'mcpr'}, inplace=True)
+    df_cpr = df_cpr.rename(columns={'timeLabel': 'year', 'value': 'cpr'})
+    df_mcpr = df_mcpr.rename(columns={'timeLabel': 'year', 'value': 'mcpr'})
     df2 = pd.merge(df_cpr, df_mcpr, on='year')
 
     # Save file
@@ -208,7 +208,7 @@ if get_asfr:
 
     # Reformat data
     df = df.loc[(df['variantLabel'] == 'Median')]
-    df.rename(columns={'timeLabel': 'year'}, inplace=True)
+    df = df.rename(columns={'timeLabel': 'year'})
     df = df.pivot(index='year', columns='ageLabel', values='value')
     df = df.round(decimals=3).drop('50-54', axis=1)
 
@@ -228,7 +228,7 @@ if get_mortality_trend:
 
     # Reformat data
     df = df.filter(['timeLabel', 'value'])
-    df.rename(columns={'timeLabel': 'year', 'value': 'crude_death_rate'}, inplace=True)
+    df = df.rename(columns={'timeLabel': 'year', 'value': 'crude_death_rate'})
 
     # Save file
     logger.info(f'Writing {country_dir}/mortality_trend.csv')
@@ -247,13 +247,13 @@ if get_mortality_prob:
     df = pd.read_csv(f'{filesdir}/{female_mort_stem}.csv')
     df_female = df.loc[(df['Location']==country) & (df['Time']==endYear)]
     df_female = df_female.filter(["AgeGrpStart", "qx"])
-    df_female.rename(columns={'AgeGrpStart': 'age', 'qx': 'female'}, inplace=True)
+    df_female = df_female.rename(columns={'AgeGrpStart': 'age', 'qx': 'female'})
 
     # Load male data from scraped data
     df = pd.read_csv(f'{filesdir}/{male_mort_stem}.csv')
     df_male = df.loc[(df['Location']==country) & (df['Time']==endYear)]
     df_male = df_male.filter(["AgeGrpStart", "qx"])
-    df_male.rename(columns={'AgeGrpStart': 'age', 'qx': 'male'}, inplace=True)
+    df_male = df_male.rename(columns={'AgeGrpStart': 'age', 'qx': 'male'})
 
     # Combine two dataframes
     df_combined = pd.merge(df_female, df_male, on="age")
@@ -273,7 +273,7 @@ if get_pop:
     df = pd.read_csv(f'{filesdir}/{pop_stem}.csv')
     filtered_df = df.loc[(df['Location']==country) & (df['Time']==endYear)]
     filtered_df = filtered_df.filter(["AgeGrpStart", "PopMale", "PopFemale"])
-    filtered_df.rename(columns={'AgeGrpStart': 'age', 'PopMale': 'male', 'PopFemale': 'female'}, inplace=True)
+    filtered_df = filtered_df.rename(columns={'AgeGrpStart': 'age', 'PopMale': 'male', 'PopFemale': 'female'})
     filtered_df[['male', 'female']] = (filtered_df[['male', 'female']] * 1000).astype(int)
 
     # Save file

--- a/fpsim/data_processing/UN_WB_data_scraping/WorldBank_data_scraping.py
+++ b/fpsim/data_processing/UN_WB_data_scraping/WorldBank_data_scraping.py
@@ -121,7 +121,7 @@ if get_pop:
     # Process data to correct format
     df = df.filter(['date', 'value'])
     df = df.rename(columns={'date': 'year', 'value': 'population'})
-    df.dropna(subset=['population'], inplace=True)
+    df = df.dropna(subset=['population'])
     df = df.sort_values('year')
 
     # Write data to csv
@@ -139,7 +139,7 @@ if get_tfr:
     # Process data to correct format
     df = df.filter(['date', 'value'])
     df = df.rename(columns={'date': 'year', 'value': 'tfr'})
-    df.dropna(subset=['tfr'], inplace=True)
+    df = df.dropna(subset=['tfr'])
     df = df.sort_values('year')
 
     # Write data to csv
@@ -157,7 +157,7 @@ if get_maternal_mortality:
     # Process data to correct format
     df = df.filter(['date', 'value'])
     df = df.rename(columns={'date': 'year', 'value': 'probs'})
-    df.dropna(subset=['probs'], inplace=True)
+    df = df.dropna(subset=['probs'])
     df['probs'] = df['probs'].astype(int)
     df = df.sort_values('year')
 
@@ -176,7 +176,7 @@ if get_infant_mortality:
     # Process data to correct format
     df = df.filter(['date', 'value'])
     df = df.rename(columns={'date': 'year', 'value': 'probs'})
-    df.dropna(subset=['probs'], inplace=True)
+    df = df.dropna(subset=['probs'])
     df = df.sort_values('year')
 
     # Write data to csv

--- a/fpsim/locations/data_utils.py
+++ b/fpsim/locations/data_utils.py
@@ -279,11 +279,11 @@ class DataLoader:
             raise ValueError(error_msg)
 
         mortality = {
-            'ages': mortality_data['age'].to_numpy(),
-            'm': mortality_data['male'].to_numpy(),
-            'f': mortality_data['female'].to_numpy(),
-            'year': mortality_trend['year'].to_numpy(),
-            'probs': mortality_trend['crude_death_rate'].to_numpy(),
+            'ages': mortality_data['age'].to_numpy(copy=True),
+            'm': mortality_data['male'].to_numpy(copy=True),
+            'f': mortality_data['female'].to_numpy(copy=True),
+            'year': mortality_trend['year'].to_numpy(copy=True),
+            'probs': mortality_trend['crude_death_rate'].to_numpy(copy=True),
         }
 
         trend_ind = np.where(mortality['year'] == data_year)


### PR DESCRIPTION
Pandas v3.0.0 introduces copy-on-write (CoW) behavior that breaks inplace editing of dataframes and makes arrays returned by .to_numpy() read-only by default.

Changes:
- Add copy=True parameter to .to_numpy() calls in age_mortality() method to create writable arrays (fpsim/locations/data_utils.py)
- Replace all inplace=True operations with return assignments in data processing scripts:
  - DHS_PMA_scripts/dhs_parse_mcprbyparity.py
  - UN_WB_data_scraping/UN_data_scraping.py
  - UN_WB_data_scraping/WorldBank_data_scraping.py
