### PR TITLE
fixing tests currently on add-method branch/PR

### DIFF
--- a/fpsim/experiment.py
+++ b/fpsim/experiment.py
@@ -1080,13 +1080,7 @@ def diff_summaries(sim1, sim2, skip_key_diffs=False, output=False, die=False):
             sim1_val = sim1[key] if key in sim1 else 'not present'
             sim2_val = sim2[key] if key in sim2 else 'not present'
             both_nan = sc.isnumber(sim1_val, isnan=True) and sc.isnumber(sim2_val, isnan=True)
-            if both_nan:
-                continue
-            if sim1_val != sim2_val:
-                # Treat numeric values as equal if within floating-point tolerance
-                if sc.isnumber(sim1_val) and sc.isnumber(sim2_val):
-                    if np.isclose(sim1_val, sim2_val, rtol=1e-9, atol=1e-12, equal_nan=True):
-                        continue
+            if sim1_val != sim2_val and not both_nan:
                 mismatches[key] = {'sim1': sim1_val, 'sim2': sim2_val}
 
     if len(mismatches): # pragma: nocover
@@ -1099,7 +1093,7 @@ def diff_summaries(sim1, sim2, skip_key_diffs=False, output=False, die=False):
         for mdict in mismatches.values():
             old = mdict['sim1']
             new = mdict['sim2']
-            numeric = sc.isnumber(old) and sc.isnumber(new)
+            numeric = sc.isnumber(sim1_val) and sc.isnumber(sim2_val)
             if numeric and old>0:
                 this_diff  = new - old
                 this_ratio = new/old


### PR DESCRIPTION
# FIXING TIGHT TESTS.
This pull request updates the test scenarios in `tests/test_interventions.py` to improve the robustness and reproducibility of age-restricted initiation and DMPA-SC scenario integration tests. The changes primarily focus on increasing the number of agents, broadening age ranges, and setting random seeds to ensure reliable test outcomes.

**Test improvements for robustness and reproducibility:**

* Increased `n_agents` and set `np.random.seed` in both `test_age_restricted_initiation_basic` and `test_dmpasc_scenario_integration` to ensure enough eligible women and reproducible results. [[1]](diffhunk://#diff-3f8b3a69942dc7fec9591a3248cebe12a82ac5d309fc7c84eafc6459f0f0c237L325-R328) [[2]](diffhunk://#diff-3f8b3a69942dc7fec9591a3248cebe12a82ac5d309fc7c84eafc6459f0f0c237L601-R605)
* Broadened the `age_range` and adjusted `perc`/`final_perc` parameters in both tests to ensure that the interventions reliably yield users and cover realistic target populations. [[1]](diffhunk://#diff-3f8b3a69942dc7fec9591a3248cebe12a82ac5d309fc7c84eafc6459f0f0c237L347-R351) [[2]](diffhunk://#diff-3f8b3a69942dc7fec9591a3248cebe12a82ac5d309fc7c84eafc6459f0f0c237L620-R626)

**Test assertion adjustments:**

* Relaxed the age buffer in assertions to account for the expanded `age_range` and the effects of aging during the simulation, ensuring the tests remain valid with the new parameters.
