### PR TITLE
Update version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fpsim"
 dynamic = ["version"]
 description = "FPsim: Family Planning Simulator"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["family planning", "women's health", "agent-based model", "simulation"]
 


### PR DESCRIPTION
Setting up an environment with `uv sync` fails with

```
romesh@ROMESH-3700X: fpsim > uv sync
  × No solution found when resolving dependencies for split (markers: python_full_version
  │ == '3.9.*'):
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and
      starsim>=3.1.0 depends on Python>=3.10, we can conclude that starsim>=3.1.0 cannot
      be used.
      And because only the following versions of starsim are available:
          starsim<=3.1.0
          starsim==3.1.1
          starsim==3.2.0
      and your project depends on starsim>=3.1.0, we can conclude that your project's
      requirements are unsatisfiable.

      hint: While the active Python version is 3.14, the resolution failed for other Python
      versions supported by your project. Consider limiting your project's supported Python
      versions using `requires-python`.

      hint: The `requires-python` value (>=3.9) includes Python versions that are not
      supported by your dependencies (e.g., starsim>=3.1.0 only supports >=3.10). Consider
      using a more restrictive `requires-python` value (like >=3.10).
  ```
  
  This is just complaining that `starsim` has been listed as requiring Python >3.10, therefore `pyproject.toml` in this project should also be >3.10 since otherwise this project is saying it's OK with 3.9 even though that would not satisfy one of its dependencies
  